### PR TITLE
v0.3.3

### DIFF
--- a/autopilot/__init__.py
+++ b/autopilot/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3'
-__author__  = 'Jonny Saunders <JLSaunders987@gmail.com>'
+__author__  = 'Jonny Saunders <j@nny.fyi>'
+__version__ = '0.3.3'

--- a/autopilot/__init__.py
+++ b/autopilot/__init__.py
@@ -1,6 +1,2 @@
 __version__ = '0.3'
 __author__  = 'Jonny Saunders <JLSaunders987@gmail.com>'
-
-from autopilot import core
-from autopilot.tasks import Task
-from autopilot.setup import setup_autopilot

--- a/autopilot/core/gui.py
+++ b/autopilot/core/gui.py
@@ -21,6 +21,7 @@ import os
 import json
 import copy
 import datetime
+import time
 from collections import OrderedDict as odict
 import numpy as np
 import ast
@@ -32,21 +33,17 @@ import itertools
 import threading
 import logging
 from operator import ior
-import pdb
 
 # adding autopilot parent directory to path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from autopilot.core.subject import Subject
 from autopilot import tasks, prefs
 from autopilot.stim.sound import sounds
 from autopilot.core.networking import Net_Node
 from functools import wraps
 from autopilot.core.utils import InvokeEvent
-#from autopilot.core.plots import gui_event
 from autopilot.core import styles
 
-import pdb
-import time
+
 
 
 def gui_event(fn):

--- a/autopilot/core/gui.py
+++ b/autopilot/core/gui.py
@@ -2428,9 +2428,9 @@ class Reassign(QtWidgets.QDialog):
             step_box.currentIndexChanged.connect(self.set_step)
 
             # add to layout
-            self.grid.addWidget(subject_lab, i%25, 0+(i/25)*3)
-            self.grid.addWidget(protocol_box, i%25, 1+(i/25)*3)
-            self.grid.addWidget(step_box, i%25, 2+(i/25)*3)
+            self.grid.addWidget(subject_lab, i%25, 0+(np.floor(i/25))*3)
+            self.grid.addWidget(protocol_box, i%25, 1+(np.floor(i/25))*3)
+            self.grid.addWidget(step_box, i%25, 2+(np.floor(i/25))*3)
 
 
 

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 
     prefs.init(prefs_file)
 
-    if hasattr(prefs, 'AUDIOSERVER') and 'AUDIO' in prefs.CONFIG:
+    if hasattr(prefs, 'AUDIOSERVER') or 'AUDIO' in prefs.CONFIG:
         if prefs.AUDIOSERVER == 'pyo':
             from autopilot.stim.sound import pyoserver
         elif prefs.AUDIOSERVER in ('jack', True):

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -234,7 +234,11 @@ class Pilot:
         self.log_formatter = logging.Formatter("%(asctime)s %(levelname)s : %(message)s")
         self.log_handler.setFormatter(self.log_formatter)
         self.logger.addHandler(self.log_handler)
-        self.logger.setLevel(logging.INFO)
+        if hasattr(prefs, 'LOGLEVEL'):
+            loglevel = getattr(logging, prefs.LOGLEVEL)
+        else:
+            loglevel = logging.WARNING
+        self.logger.setLevel(loglevel)
         self.logger.info('Pilot Logging Initiated')
 
     #################################################################

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -695,10 +695,11 @@ class Pilot:
         h5f, table, row = self.open_file()
 
         # TODO: Init sending continuous data here
-
+        self.logger.debug('Starting task loop')
         while True:
             # Calculate next stage data and prep triggers
             data = next(self.task.stages)() # Double parens because next just gives us the function, we still have to call it
+            self.logger.debug('called stage method')
 
             if data:
                 data['pilot'] = self.name
@@ -718,9 +719,12 @@ class Pilot:
                 if 'TRIAL_END' in data.keys():
                     row.append()
                     table.flush()
+                self.logger.debug('sent data')
+
 
             # Wait on the stage lock to clear
             self.stage_block.wait()
+            self.logger.debug('stage lock passed')
 
             # If the running flag gets set, we're closing.
             if not self.running.is_set():
@@ -728,6 +732,7 @@ class Pilot:
                 self.task = None
                 row.append()
                 table.flush()
+                self.logger.debug('stopping task')
                 break
 
         h5f.flush()

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     if hasattr(prefs, 'AUDIOSERVER') and 'AUDIO' in prefs.CONFIG:
         if prefs.AUDIOSERVER == 'pyo':
             from autopilot.stim.sound import pyoserver
-        elif prefs.AUDIOSERVER == 'jack':
+        elif prefs.AUDIOSERVER in ('jack', True):
             from autopilot.stim.sound import jackclient
 
 from autopilot.core.networking import Pilot_Station, Net_Node, Message

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -172,7 +172,7 @@ class Pilot:
         self.init_pigpio()
 
         # Init audio server
-        if hasattr(prefs, 'AUDIOSERVER') and 'AUDIO' in prefs.CONFIG:
+        if hasattr(prefs, 'AUDIOSERVER') or 'AUDIO' in prefs.CONFIG:
             self.init_audio()
 
         # Init Station

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -18,11 +18,13 @@ import socket
 import json
 import base64
 import subprocess
+import warnings
 import numpy as np
 import pandas as pd
 from scipy.stats import linregress
 
 import tables
+warnings.simplefilter('ignore', category=tables.NaturalNameWarning)
 
 from autopilot import prefs
 
@@ -628,6 +630,10 @@ class Pilot:
 
         Opens `prefs.DATADIR/local.h5`, creates a group for the current subject,
         a new table for the current day.
+
+        .. todo::
+
+            This needs to be unified with a general file constructor abstracted from :class:`.Subject` so it doesn't reimplement file creation!!
 
         Returns:
             (:class:`tables.File`, :class:`tables.Table`,

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -632,7 +632,7 @@ class Pilot:
         local_file = os.path.join(prefs.DATADIR, 'local.h5')
         try:
             h5f = tables.open_file(local_file, mode='a')
-        except IOError as e:
+        except (IOError, tables.HDF5ExtError) as e:
             self.logger.warning("local file was broken, making new")
             self.logger.warning(e)
             os.remove(local_file)

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -1,11 +1,6 @@
-#!/usr/bin/python2.7
-
 """
 
 """
-
-__version__ = '0.2'
-__author__ = 'Jonny Saunders <jsaunder@uoregon.edu>'
 
 import os
 import sys

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -593,7 +593,7 @@ class Pilot:
         if prefs.AUDIOSERVER == 'pyo':
             self.server = pyoserver.pyo_server()
             self.logger.info("pyo server started")
-        elif prefs.AUDIOSERVER == 'jack':
+        elif prefs.AUDIOSERVER in ('jack', True):
             self.jackd = external.start_jackd()
             self.server = jackclient.JackClient()
             self.server.start()

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -199,10 +199,10 @@ class Pilot:
         self.pulls = []
         if hasattr(prefs, 'PULLUPS'):
             for pin in prefs.PULLUPS:
-                self.pulls.append(gpio.Digital_Out(int(pin), pull='U'))
+                self.pulls.append(gpio.Digital_Out(int(pin), pull='U', polarity=0))
         if hasattr(prefs, 'PULLDOWNS'):
             for pin in prefs.PULLDOWNS:
-                self.pulls.append(gpio.Digital_Out(int(pin), pull='D'))
+                self.pulls.append(gpio.Digital_Out(int(pin), pull='D', polarity=1))
 
         # check if the calibration file needs to be updated
 

--- a/autopilot/core/plots.py
+++ b/autopilot/core/plots.py
@@ -17,7 +17,6 @@ import logging
 import os
 import numpy as np
 import PySide2 # have to import to tell pyqtgraph to use it
-#import PySide
 import pandas as pd
 from PySide2 import QtGui
 from PySide2 import QtCore
@@ -35,7 +34,6 @@ from queue import Queue, Empty, Full
 pg.setConfigOptions(antialias=True)
 # from pyqtgraph.widgets.RawImageWidget import RawImageWidget, RawImageGLWidget
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from autopilot import tasks, prefs
 from autopilot.core import styles
 from .utils import InvokeEvent, Invoker

--- a/autopilot/core/subject.py
+++ b/autopilot/core/subject.py
@@ -18,6 +18,7 @@ import json
 import pandas as pd
 import warnings
 import typing
+import warnings
 from copy import copy
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from autopilot.tasks import GRAD_LIST, TASK_LIST
@@ -28,6 +29,9 @@ if sys.version_info >= (3,0):
     import queue
 else:
     import Queue as queue
+
+# suppress pytables natural name warnings
+warnings.simplefilter('ignore', category=tables.NaturalNameWarning)
 
 import pdb
 import numpy as np
@@ -501,7 +505,7 @@ class Subject(object):
                     # if this task has sounds, make columns for them
                     # TODO: Make stim managers return a list of properties for their sounds
                     if 'stim' in step.keys():
-                        if 'manager' in step['stim'].keys():
+                        if 'groups' in step['stim'].keys():
                             # managers have stim nested within groups, but this is still really ugly
                             sound_params = {}
                             for g in step['stim']['groups']:

--- a/autopilot/core/subject.py
+++ b/autopilot/core/subject.py
@@ -20,7 +20,6 @@ import warnings
 import typing
 import warnings
 from copy import copy
-# sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from autopilot.tasks import GRAD_LIST, TASK_LIST
 from autopilot import prefs
 from autopilot.stim.sound.sounds import STRING_PARAMS

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -1,6 +1,3 @@
-__version__ = '0.3'
-__author__  = 'Jonny Saunders <JLSaunders987@gmail.com>'
-
 import argparse
 import json
 import sys

--- a/autopilot/core/utils.py
+++ b/autopilot/core/utils.py
@@ -1,4 +1,3 @@
-# import numpy as np
 from autopilot import prefs
 # if prefs.AGENT in ("TERMINAL", "DOCS"):
 HAVE_PYSIDE = False

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -80,12 +80,15 @@ def start_pigpiod():
                 prefs.PIGPIOMASK = str(prefs.PIGPIOMASK).zfill(28)
             launch_pigpiod += ' -x ' + prefs.PIGPIOMASK
 
-        proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True)
+        proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True,
+                                preexec_fn=os.setsid())
         globals()['PIGPIO_DAEMON'] = proc
 
         # kill process when session ends
         def kill_proc():
-            proc.kill()
+            # https: // stackoverflow.com / a / 4791612
+            # proc.kill()
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             sys.exit(1)
         atexit.register(kill_proc)
         signal.signal(signal.SIGTERM, kill_proc)

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -119,7 +119,9 @@ def start_jackd():
     #     # launch_jackd = " ".join([lib_string, driver_string, jackd_bin, jackd_string])
     #
     # else:
-    jackd_bin = 'jackd'
+    jackd_bin = shutil.which('jackd')
+
+    #jackd_bin = 'jackd'
 
         # launch_jackd = " ".join([jackd_bin, jackd_string])
 
@@ -132,7 +134,7 @@ def start_jackd():
     atexit.register(lambda jackd_proc=proc: jackd_proc.kill())
 
     # sleep to let it boot
-    sleep(1)
+    sleep(5)
 
     return proc
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -60,7 +60,7 @@ except (ImportError, OSError):
 
 def start_pigpiod():
     if not PIGPIO:
-        raise ImportError('pigpio was not found in autopilot.external')
+        raise ImportError('the pigpiod daemon was not found! use autopilot.setup.')
 
     with globals()['PIGPIO_LOCK']:
         if globals()['PIGPIO_DAEMON']:
@@ -69,7 +69,7 @@ def start_pigpiod():
         launch_pigpiod = shutil.which('pigpiod')
         if launch_pigpiod is None:
             raise RuntimeError('the pigpiod binary was not found!')
-        
+
         if hasattr(prefs, 'PIGPIOARGS'):
             launch_pigpiod += ' ' + prefs.PIGPIOARGS
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -5,13 +5,14 @@ from autopilot import prefs
 import atexit
 from time import sleep
 import threading
+import shutil
 
 PIGPIO = False
 PIGPIO_DAEMON = None
 PIGPIO_LOCK = threading.Lock()
 try:
-    import pigpio
-    PIGPIO = True
+    if shutil.which('pigpiod') is not None:
+        PIGPIO = True
 
 except ImportError:
     pass
@@ -65,7 +66,10 @@ def start_pigpiod():
         if globals()['PIGPIO_DAEMON']:
             return globals()['PIGPIO_DAEMON']
 
-        launch_pigpiod = os.path.join(pigpio.__path__._path[0], 'pigpiod')
+        launch_pigpiod = shutil.which('pigpiod')
+        if launch_pigpiod is None:
+            raise RuntimeError('the pigpiod binary was not found!')
+        
         if hasattr(prefs, 'PIGPIOARGS'):
             launch_pigpiod += ' ' + prefs.PIGPIOARGS
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -101,6 +101,10 @@ def start_jackd():
     else:
         jackd_string = ""
 
+    # replace string fs with number
+    if hasattr(prefs, 'FS'):
+        jackd_string.replace('-rfs', f'-r{prefs.FS}')
+
     # construct rest of launch string!
     # if JACKD_MODULE:
     #     jackd_path = os.path.join(autopilot_jack.__path__._path[0])

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -10,7 +10,7 @@ PIGPIO = False
 PIGPIO_DAEMON = None
 PIGPIO_LOCK = threading.Lock()
 try:
-    from autopilot.external import pigpio
+    import pigpio
     PIGPIO = True
 
 except ImportError:
@@ -77,7 +77,7 @@ def start_pigpiod():
 
         proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True)
         globals()['PIGPIO_DAEMON'] = proc
-    
+
         # kill process when session ends
         atexit.register(lambda pigpio_proc=proc: pigpio_proc.kill())
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -63,7 +63,7 @@ def start_pigpiod():
         raise ImportError('the pigpiod daemon was not found! use autopilot.setup.')
 
     with globals()['PIGPIO_LOCK']:
-        if globals()['PIGPIO_DAEMON']:
+        if globals()['PIGPIO_DAEMON'] is not None:
             return globals()['PIGPIO_DAEMON']
 
         launch_pigpiod = shutil.which('pigpiod')

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -84,7 +84,7 @@ def start_pigpiod():
         globals()['PIGPIO_DAEMON'] = proc
 
         # kill process when session ends
-        def kill_proc():
+        def kill_proc(*args):
             proc.kill()
             sys.exit(1)
         atexit.register(kill_proc)
@@ -140,7 +140,7 @@ def start_jackd():
     globals()['JACKD_PROCESS'] = proc
 
     # kill process when session ends
-    def kill_proc():
+    def kill_proc(*args):
         proc.kill()
         sys.exit(1)
     atexit.register(kill_proc)

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -6,6 +6,7 @@ import atexit
 from time import sleep
 import threading
 import shutil
+import signal
 
 PIGPIO = False
 PIGPIO_DAEMON = None
@@ -83,7 +84,10 @@ def start_pigpiod():
         globals()['PIGPIO_DAEMON'] = proc
 
         # kill process when session ends
-        atexit.register(lambda pigpio_proc=proc: pigpio_proc.kill())
+        def kill_proc():
+            proc.kill()
+        atexit.register(kill_proc)
+        signal.signal(signal.SIGTERM, kill_proc)
 
         # sleep to let it boot up
         sleep(1)
@@ -135,7 +139,10 @@ def start_jackd():
     globals()['JACKD_PROCESS'] = proc
 
     # kill process when session ends
-    atexit.register(lambda jackd_proc=proc: jackd_proc.kill())
+    def kill_proc():
+        proc.kill()
+    atexit.register(kill_proc)
+    signal.signal(signal.SIGTERM, kill_proc)
 
     # sleep to let it boot
     sleep(2)

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -80,15 +80,12 @@ def start_pigpiod():
                 prefs.PIGPIOMASK = str(prefs.PIGPIOMASK).zfill(28)
             launch_pigpiod += ' -x ' + prefs.PIGPIOMASK
 
-        proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True,
-                                preexec_fn=os.setsid())
+        proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True)
         globals()['PIGPIO_DAEMON'] = proc
 
         # kill process when session ends
         def kill_proc():
-            # https: // stackoverflow.com / a / 4791612
-            # proc.kill()
-            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            proc.kill()
             sys.exit(1)
         atexit.register(kill_proc)
         signal.signal(signal.SIGTERM, kill_proc)

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -138,7 +138,7 @@ def start_jackd():
     atexit.register(lambda jackd_proc=proc: jackd_proc.kill())
 
     # sleep to let it boot
-    sleep(5)
+    sleep(2)
 
     return proc
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -86,6 +86,7 @@ def start_pigpiod():
         # kill process when session ends
         def kill_proc():
             proc.kill()
+            sys.exit(1)
         atexit.register(kill_proc)
         signal.signal(signal.SIGTERM, kill_proc)
 
@@ -141,6 +142,7 @@ def start_jackd():
     # kill process when session ends
     def kill_proc():
         proc.kill()
+        sys.exit(1)
     atexit.register(kill_proc)
     signal.signal(signal.SIGTERM, kill_proc)
 

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -103,7 +103,7 @@ def start_jackd():
 
     # replace string fs with number
     if hasattr(prefs, 'FS'):
-        jackd_string.replace('-rfs', f'-r{prefs.FS}')
+        jackd_string = jackd_string.replace('-rfs', f'-r{prefs.FS}')
 
     # construct rest of launch string!
     # if JACKD_MODULE:

--- a/autopilot/external/__init__.py
+++ b/autopilot/external/__init__.py
@@ -6,6 +6,7 @@ import atexit
 from time import sleep
 
 PIGPIO = False
+PIGPIO_DAEMON = None
 try:
     from autopilot.external import pigpio
     PIGPIO = True
@@ -57,6 +58,10 @@ except (ImportError, OSError):
 def start_pigpiod():
     if not PIGPIO:
         raise ImportError('pigpio was not found in autopilot.external')
+
+    if globals()['PIGPIO_DAEMON']:
+        return globals()['PIGPIO_DAEMON']
+
     launch_pigpiod = os.path.join(pigpio.__path__._path[0], 'pigpiod')
     if hasattr(prefs, 'PIGPIOARGS'):
         launch_pigpiod += ' ' + prefs.PIGPIOARGS
@@ -68,6 +73,7 @@ def start_pigpiod():
         launch_pigpiod += ' -x ' + prefs.PIGPIOMASK
 
     proc = subprocess.Popen('sudo ' + launch_pigpiod, shell=True)
+    globals()['PIGPIO_DAEMON'] = proc
 
     # kill process when session ends
     atexit.register(lambda pigpio_proc=proc: pigpio_proc.kill())

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -1269,7 +1269,7 @@ class Solenoid(Digital_Out):
             self.calibration = prefs.PORT_CALIBRATION[self.name]
         except KeyError:
             # try using name prepended with PORTS_, which happens for hardware objects with implicit names
-            self.calibration = prefs.PORT_CALIBRATION[self.name.lstrip('PORTS_')]
+            self.calibration = prefs.PORT_CALIBRATION[self.name.replace('PORTS_', '')]
 
         # compute duration from slope and intercept
         duration = round(float(self.calibration['intercept']) + (float(self.calibration['slope']) * float(vol)))

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -307,7 +307,7 @@ class Digital_Out(GPIO):
             self.pig.set_mode(self.pin_bcm, pigpio.OUTPUT)
             self.set(self.off)
 
-    def set(self, value):
+    def set(self, value: bool):
         """
         Set pin logic level.
 
@@ -863,14 +863,15 @@ class PWM(Digital_Out):
         Returns:
 
         """
+        # FIXME: reimplementing parent release method here because of inconsistent use of self.off -- unify API and fix!!
         try:
-            self.set(self.off)
+            self.stop_script()
+            self.set(0) # clean values should handle inversion, don't use self.off
             time.sleep(0.1)
+            self.pig.stop()
         except AttributeError:
             # has already been called, pig already destroyed
             pass
-        finally:
-            super(PWM, self).release()
 
 
 class LED_RGB(Digital_Out):

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -698,7 +698,7 @@ class Digital_In(GPIO):
             cb = self.pig.callback(self.pin_bcm, trigger_ud, self.event.set)
             self.callbacks.append(cb)
         elif evented and not self.event:
-            Exception('We have no internal event to set!')
+            raise Exception('We have no internal event to set!')
 
         cb = self.pig.callback(self.pin_bcm, trigger_ud, callback_fn)
         self.callbacks.append(cb)

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -583,10 +583,16 @@ class Digital_Out(GPIO):
         """
         Stops last running script, sets to :attr:`~.Digital_Out.off`, and calls :meth:`.GPIO.release`
         """
-        self.stop_script()
-        self.set(self.off)
-        time.sleep(0.1)
-        super(Digital_Out, self).release()
+        try:
+            self.stop_script()
+            self.set(self.off)
+            time.sleep(0.1)
+        except AttributeError:
+            # self.pig has already been deleted (release has already been called)
+            # so self.pig has no attribute 'send' because it is None
+            pass
+        finally:
+            super(Digital_Out, self).release()
 
 
 class Digital_In(GPIO):

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -960,7 +960,7 @@ class LED_RGB(Digital_Out):
         self.stop_script()
 
         # if we were given a value, ignore other arguments
-        if value:
+        if value is not None:
             if isinstance(value, int) or isinstance(value, float):
                 for channel in self.channels.values():
                     channel.set(value)
@@ -968,7 +968,7 @@ class LED_RGB(Digital_Out):
                 for channel_key, color_val in zip(('r','g','b'), value):
                     self.channels[channel_key].set(color_val)
             else:
-                ValueError('Value must either be a single value or a tuple of (r,g,b)')
+                raise ValueError('Value must either be a single value or a tuple of (r,g,b)')
         else:
             if r:
                 self.channels['r'].set(r)

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -1265,7 +1265,11 @@ class Solenoid(Digital_Out):
             self.name = self.get_name()
 
         # prefs should have loaded any calibration
-        self.calibration = prefs.PORT_CALIBRATION[self.name]
+        try:
+            self.calibration = prefs.PORT_CALIBRATION[self.name]
+        except KeyError:
+            # try using name prepended with PORTS_, which happens for hardware objects with implicit names
+            self.calibration = prefs.PORT_CALIBRATION[self.name.lstrip('PORTS_')]
 
         # compute duration from slope and intercept
         duration = round(float(self.calibration['intercept']) + (float(self.calibration['slope']) * float(vol)))

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -863,9 +863,14 @@ class PWM(Digital_Out):
         Returns:
 
         """
-        self.set(self.off)
-        time.sleep(0.1)
-        super(PWM, self).release()
+        try:
+            self.set(self.off)
+            time.sleep(0.1)
+        except AttributeError:
+            # has already been called, pig already destroyed
+            pass
+        finally:
+            super(PWM, self).release()
 
 
 class LED_RGB(Digital_Out):

--- a/autopilot/hardware/gpio.py
+++ b/autopilot/hardware/gpio.py
@@ -20,6 +20,7 @@ import itertools
 
 from autopilot import prefs
 from autopilot.hardware import Hardware, BOARD_TO_BCM
+from autopilot import external
 
 ENABLED = False
 """
@@ -103,6 +104,7 @@ class GPIO(Hardware):
     Attributes:
         pig (:class:`pigpio.pi`): An object that manages connection to the pigpio daemon. See docs at http://abyz.me.uk/rpi/pigpio/python.html
         CONNECTED (bool): Whether the connection to pigpio was successful
+        pigpiod: Reference to the pigpiod process launched by :func:`.external.start_pigpiod`
         pin (int): The Board-numbered GPIO pin of this object.
         pin_bcm (int): The BCM number of the connected pin -- used by pigpio. Converted from pin passed as argument on initialization,
             which is assumed to be the board number.
@@ -135,6 +137,7 @@ class GPIO(Hardware):
             self.logger.warning('pin_bcm is defined as a property without a setter so cant be set')
 
         self.pig = None
+        self.pigpiod = None
 
         # init pigpio
         self.CONNECTED = False
@@ -158,6 +161,7 @@ class GPIO(Hardware):
         Returns:
             bool: True if connection was successful, False otherwise
         """
+        self.pigpiod = external.start_pigpiod()
         self.pig = pigpio.pi()
         if self.pig.connected:
             return True

--- a/autopilot/prefs.py
+++ b/autopilot/prefs.py
@@ -11,7 +11,7 @@ Before importing any other autopilot module,
 Examples:
 
     from autopilot import prefs
-    prefs_file = '/usr/autopilot/prefs.json' # or some .json prefs file
+    prefs_file = '~/autopilot/prefs.json' # or some .json prefs file
     prefs.init(prefs_file)
 
 And to add a pref

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -1,0 +1,94 @@
+"""
+Run scripts to setup system dependencies and autopilot plugins
+
+.. example::
+
+    > # to list scripts
+    > autopilot.setup.run_script --list
+
+    > # to execute one script (setup hifiberry soundcard)
+    > autopilot.setup.run_script hifiberry
+
+    > # to execute multiple scripts
+    > autopilot.setup.run_script hifiberry jackd
+
+"""
+import subprocess
+from autopilot.setup.setup_autopilot import PILOT_ENV_CMDS
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Run autopilot setup script(s)")
+parser.add_argument('scripts', nargs='+', type=str)
+parser.add_argument('-l', '--list', help="list available setup scripts!", action='store_true')
+
+
+def call_series(commands, series_name=None):
+    """
+    Call a series of commands, giving a single return code on completion or failure
+
+    :param commands:
+    :return:
+    """
+    if series_name:
+        print('\n\033[1;37;42m Running commands for {}\u001b[0m'.format(series_name))
+
+    # have to just combine them -- can't do multiple calls b/c shell doesn't preserve between them
+    combined_calls = ""
+    last_command = len(commands)-1
+    for i, command in enumerate(commands):
+        join_with = " && "
+
+        if isinstance(command, str):
+            # just a command, default necessary
+            combined_calls += command
+        elif isinstance(command, dict):
+            combined_calls += command['command']
+
+            if command.get('optional', False):
+                join_with = "; "
+
+        if i < last_command:
+            combined_calls += join_with
+
+
+    print('Executing:\n    {}'.format(combined_calls))
+
+    result = subprocess.run(combined_calls, shell=True, executable='/bin/bash')
+
+    status = False
+    if result.returncode == 0:
+        status = True
+
+    if series_name:
+        if status:
+            print('\n\033[1;37;42m  {} Successful, you lucky duck\u001b[0m'.format(series_name))
+        else:
+            print('\n\033[1;37;41m  {} Failed, check the error message & ur crystal ball\u001b[0m'.format(series_name))
+
+    return status
+
+
+def run_script(script_name):
+    if script_name in PILOT_ENV_CMDS.keys():
+        call_series(PILOT_ENV_CMDS[script_name], script_name)
+    else:
+        Exception('No script named {}, must be one of {}'.format(script_name, "\n".join(PILOT_ENV_CMDS.keys())))
+
+
+def list_scripts():
+    print('Available Scripts:')
+    for script_name in sorted(PILOT_ENV_CMDS.keys()):
+        print(f'{script_name}: {PILOT_ENV_CMDS[script_name]["text"]}\n')
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.list:
+        list_scripts()
+        sys.exit()
+    elif args.scripts:
+        call_series(args.scripts)
+        sys.exit()
+    else:
+        raise RuntimeError('Need to give name of one or multiple scripts, ')

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -79,7 +79,7 @@ def run_script(script_name):
 def list_scripts():
     print('Available Scripts:')
     for script_name in sorted(ENV_PILOT.keys()):
-        print(f'{script_name}: {ENV_PILOT[script_name]["text"]}\n')
+        print(f'\033[1;37;42m {script_name}\u001b[0m : {ENV_PILOT[script_name]["text"]}')
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -19,8 +19,8 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser(description="Run autopilot setup script(s)")
-parser.add_argument('scripts', nargs='+', type=str)
-parser.add_argument('-l', '--list', help="list available setup scripts!", action='store_true')
+parser.add_argument('scripts', nargs='*', type=str)
+parser.add_argument('--list', help="list available setup scripts!", action='store_true')
 
 
 def call_series(commands, series_name=None):

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -14,7 +14,7 @@ Run scripts to setup system dependencies and autopilot plugins
 
 """
 import subprocess
-from autopilot.setup.scripts import PILOT_ENV_CMDS
+from autopilot.setup.scripts import PILOT_ENV_CMDS, ENV_PILOT
 import argparse
 import sys
 
@@ -78,8 +78,8 @@ def run_script(script_name):
 
 def list_scripts():
     print('Available Scripts:')
-    for script_name in sorted(PILOT_ENV_CMDS.keys()):
-        print(f'{script_name}: {PILOT_ENV_CMDS[script_name]["text"]}\n')
+    for script_name in sorted(ENV_PILOT.keys()):
+        print(f'{script_name}: {ENV_PILOT[script_name]["text"]}\n')
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -4,13 +4,13 @@ Run scripts to setup system dependencies and autopilot plugins
 .. example::
 
     > # to list scripts
-    > autopilot.setup.run_script --list
+    > python3 -m autopilot.setup.run_script --list
 
     > # to execute one script (setup hifiberry soundcard)
-    > autopilot.setup.run_script hifiberry
+    > python3 -m autopilot.setup.run_script hifiberry
 
     > # to execute multiple scripts
-    > autopilot.setup.run_script hifiberry jackd
+    > python3 -m autopilot.setup.run_script hifiberry jackd
 
 """
 import subprocess

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -77,9 +77,18 @@ def run_script(script_name):
 
 
 def list_scripts():
-    print('Available Scripts:')
+    print('\nAvailable Scripts:\n----------------------------')
+
+    # find longest script name
+    longest_name = 0
+    for script_name in ENV_PILOT.keys():
+        if len(script_name) > longest_name:
+            longest_name = len(script_name)
+
+
     for script_name in sorted(ENV_PILOT.keys()):
-        print(f'\033[1;37;42m {script_name}\u001b[0m : {ENV_PILOT[script_name]["text"]}')
+        pad = " " * (longest_name - len(script_name))
+        print(f'\033[1;37;42m{script_name}{pad}\u001b[0m : {ENV_PILOT[script_name]["text"]}')
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -14,7 +14,7 @@ Run scripts to setup system dependencies and autopilot plugins
 
 """
 import subprocess
-from autopilot.setup.setup_autopilot import PILOT_ENV_CMDS
+from autopilot.setup.scripts import PILOT_ENV_CMDS
 import argparse
 import sys
 

--- a/autopilot/setup/run_script.py
+++ b/autopilot/setup/run_script.py
@@ -75,6 +75,27 @@ def run_script(script_name):
     else:
         Exception('No script named {}, must be one of {}'.format(script_name, "\n".join(PILOT_ENV_CMDS.keys())))
 
+def run_scripts(scripts):
+    env_results = {}
+    for script_name in scripts:
+        commands = PILOT_ENV_CMDS[script_name]
+        env_results[script_name] = call_series(commands, script_name)
+
+    # make results string
+    env_result = "\033[0;32;40m\n--------------------------------\nScript Results:\n"
+    for config, result in env_results.items():
+        if result:
+            env_result += "  [ SUCCESS ] "
+        else:
+            env_result += "  [ FAILURE ] "
+
+        env_result += config
+        env_result += '\n'
+
+    env_result += '--------------------------------\u001b[0m'
+
+    print(env_result)
+
 
 def list_scripts():
     print('\nAvailable Scripts:\n----------------------------')
@@ -97,7 +118,7 @@ if __name__ == "__main__":
         list_scripts()
         sys.exit()
     elif args.scripts:
-        call_series(args.scripts)
+        run_scripts(args.scripts)
         sys.exit()
     else:
         raise RuntimeError('Need to give name of one or multiple scripts, ')

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -106,7 +106,7 @@ PILOT_ENV_CMDS = {
             "sudo /etc/init.d/dphys-swapfile stop",
             "sudo /etc/init.d/dphys-swapfile start",
             "make -j4",
-            "sudo make install",
+            "sudo --preserve-env=PATH make install",
             "sudo ldconfig",
             "sudo sed -i 's/^CONF_SWAPSIZE=2048/CONF_SWAPSIZE=100/g' /etc/dphys-swapfile",
             "sudo /etc/init.d/dphys-swapfile stop",
@@ -122,7 +122,7 @@ PILOT_ENV_CMDS = {
         'unzip master.zip',
         'cd pigpio-master',
         'make -j4',
-        'sudo make install',
+        'sudo --preserve-env=PATH make install',
         'cd ..',
         'sudo rm -rf ./pigpio-master',
         'sudo rm ./master.zip'

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -1,0 +1,117 @@
+from collections import OrderedDict as odict
+
+ENV_PILOT = odict({
+    'env_pilot'   : {'type': 'bool',
+                     'text': 'install system packages necessary for autopilot? (required if they arent already)'},
+    'performance' : {'type': 'bool',
+                     'text': 'Do performance enhancements? (recommended, change cpu governor and give more memory to audio)'},
+    'change_pw': {'type': 'bool',
+                  'text': "If you haven't, you should change the default raspberry pi password or you _will_ get your identity stolen. Change it now?"},
+    'set_locale': {'type': 'bool',
+                   'text': 'Would you like to set your locale?'},
+    'hifiberry' : {'type': 'bool',
+                   'text': 'Setup Hifiberry DAC/AMP?'},
+    'viz'       : {'type': 'bool',
+                   'text': 'Install X11 server and psychopy for visual stimuli?'},
+    'bluetooth' : {'type': 'bool',
+                   'text': 'Disable Bluetooth? (recommended unless you\'re using it <3'},
+    'systemd'   : {'type': 'bool',
+                   'text': 'Install Autopilot as a systemd service?\nIf you are running this command in a virtual environment it will be used to launch Autopilot'},
+    'jackd'     : {'type': 'bool',
+                   'text': 'Install jack audio (required if AUDIOSERVER == jack)'}
+})
+PILOT_ENV_CMDS = {
+    'performance':
+        ['sudo systemctl disable raspi-config',
+         'sudo sed -i \'/^exit 0/i echo "performance" | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor\' /etc/rc.local',
+         'sudo sh -c "echo @audio - memlock 256000 >> /etc/security/limits.conf"',
+         'sudo sh -c "echo @audio - rtprio 75 >> /etc/security/limits.conf"',
+         ],
+    'performance_cameras':
+        [
+            "sudo sh -c 'echo options uvcvideo nodrop=1 timeout=10000 quirks=0x80 > /etc/modprobe.d/uvcvideo.conf'",
+            "sudo rmmod uvcvideo",
+            "sudo modprobe uvcvideo",
+            "sudo sed -i \"/^exit 0/i sudo sh -c 'echo ${usbfs_size} > /sys/module/usbcore/parameters/usbfs_memory_mb'\" /etc/rc.local"
+        ],
+    'change_pw': ['passwd'],
+    'set_locale': ['sudo dpkg-reconfigure locales',
+                   'sudo dpkg-reconfigure keyboard-configuration'],
+    'hifiberry':
+        [
+            {'command':'sudo adduser pi i2c', 'optional':True},
+            'sudo sed -i \'s/^dtparam=audio=on/#dtparam=audio=on/g\' /boot/config.txt',
+            'sudo sed -i \'$s/$/\\ndtoverlay=hifiberry-dacplus\\ndtoverlay=i2s-mmap\\ndtoverlay=i2c-mmap\\ndtparam=i2c1=on\\ndtparam=i2c_arm=on/\' /boot/config.txt',
+            'echo -e \'pcm.!default {\\n type hw card 0\\n}\\nctl.!default {\\n type hw card 0\\n}\' | sudo tee /etc/asound.conf'
+        ],
+    'viz': [],
+    'bluetooth':
+        [
+            'sudo sed - i \'$s/$/\ndtoverlay=pi3-disable-bt/\' / boot / config.txt',
+            'sudo systemctl disable hciuart.service',
+            'sudo systemctl disable bluealsa.service',
+            'sudo systemctl disable bluetooth.service'
+        ],
+    'jackd':
+        ['sudo apt update && sudo apt install -y jackd2'],
+    'jackd_source':
+        [
+            "git clone git://github.com/jackaudio/jack2 --depth 1",
+            "cd jack2",
+            "./waf configure --alsa=yes --libdir=/usr/lib/arm-linux-gnueabihf/",
+            "./waf build -j6",
+            "sudo ./waf install",
+            "sudo ldconfig",
+            "sudo sh -c \"echo @audio - memlock 256000 >> /etc/security/limits.conf\"",             # giving jack more juice
+            "sudo sh -c \"echo @audio - rtprio 75 >> /etc/security/limits.conf\"",
+            "cd ..",
+            "rm -rf ./jack2"
+        ],
+    'opencv':
+        [
+            "sudo apt-get install -y build-essential cmake ccache unzip pkg-config libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev ffmpeg libgtk-3-dev libcanberra-gtk* libatlas-base-dev gfortran python2-dev python-numpy",
+            "git clone https://github.com/opencv/opencv.git",
+            "git clone https://github.com/opencv/opencv_contrib",
+            "cd opencv",
+            "mkdir build",
+            "cd build",
+            "cmake -D CMAKE_BUILD_TYPE=RELEASE \
+                -D CMAKE_INSTALL_PREFIX=/usr/local \
+                -D OPENCV_EXTRA_MODULES_PATH=/home/pi/git/opencv_contrib/modules \
+                -D BUILD_TESTS=OFF \
+                -D BUILD_PERF_TESTS=OFF \
+                -D BUILD_DOCS=OFF \
+                -D WITH_TBB=ON \
+                -D CMAKE_CXX_FLAGS=\"-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0\" \
+                -D WITH_OPENMP=ON \
+                -D WITH_IPP=OFF \
+                -D WITH_OPENCL=ON \
+                -D WITH_V4L=ON \
+                -D WITH_LIBV4L=ON \
+                -D ENABLE_NEON=ON \
+                -D ENABLE_VFPV3=ON \
+                -D PYTHON3_EXECUTABLE=/usr/bin/python3 \
+                -D PYTHON_INCLUDE_DIR=/usr/include/python3.7 \
+                -D PYTHON_INCLUDE_DIR2=/usr/include/arm-linux-gnueabihf/python3.7 \
+                -D OPENCV_ENABLE_NONFREE=ON \
+                -D INSTALL_PYTHON_EXAMPLES=OFF \
+                -D WITH_CAROTENE=ON \
+                -D CMAKE_SHARED_LINKER_FLAGS='-latomic' \
+                -D BUILD_EXAMPLES=OFF ..",
+            "sudo sed -i 's/^CONF_SWAPSIZE=100/CONF_SWAPSIZE=2048/g' /etc/dphys-swapfile", # increase size of swapfile so multicore build works
+            "sudo /etc/init.d/dphys-swapfile stop",
+            "sudo /etc/init.d/dphys-swapfile start",
+            "make -j4",
+            "sudo make install",
+            "sudo ldconfig",
+            "sudo sed -i 's/^CONF_SWAPSIZE=2048/CONF_SWAPSIZE=100/g' /etc/dphys-swapfile",
+            "sudo /etc/init.d/dphys-swapfile stop",
+            "sudo /etc/init.d/dphys-swapfile start"
+        ],
+    'env_pilot':
+        [
+            "sudo apt-get update",
+            "sudo apt-get install -y build-essential cmake git python3-dev libatlas-base-dev libsamplerate0-dev libsndfile1-dev libreadline-dev libasound-dev i2c-tools libportmidi-dev liblo-dev libhdf5-dev libzmq-dev libffi-dev",
+        ]
+
+}

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict as odict
 
+# TODO: merge these into one...
+
 ENV_PILOT = odict({
     'env_pilot'   : {'type': 'bool',
                      'text': 'install system packages necessary for autopilot? (required if they arent already)'},

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -20,7 +20,9 @@ ENV_PILOT = odict({
     'systemd'   : {'type': 'bool',
                    'text': 'Install Autopilot as a systemd service?\nIf you are running this command in a virtual environment it will be used to launch Autopilot'},
     'jackd'     : {'type': 'bool',
-                   'text': 'Install jack audio (required if AUDIOSERVER == jack)'}
+                   'text': 'Install jack audio (required if AUDIOSERVER == jack)'},
+    'pigpiod'   : {'type': 'bool',
+                   'text': 'Install pigpio daemon'}
 })
 PILOT_ENV_CMDS = {
     'performance':
@@ -114,6 +116,16 @@ PILOT_ENV_CMDS = {
         [
             "sudo apt-get update",
             "sudo apt-get install -y build-essential cmake git python3-dev libatlas-base-dev libsamplerate0-dev libsndfile1-dev libreadline-dev libasound-dev i2c-tools libportmidi-dev liblo-dev libhdf5-dev libzmq-dev libffi-dev",
-        ]
+        ],
+    'pigpiod':[
+        'wget https://github.com/sneakers-the-rat/pigpio/archive/master.zip',
+        'unzip master.zip',
+        'cd pigpio-master',
+        'make -j4',
+        'sudo make install',
+        'cd ..',
+        'rm -rf ./pigpio-master',
+        'rm ./master.zip'
+    ]
 
 }

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -124,8 +124,8 @@ PILOT_ENV_CMDS = {
         'make -j4',
         'sudo make install',
         'cd ..',
-        'rm -rf ./pigpio-master',
-        'rm ./master.zip'
+        'sudo rm -rf ./pigpio-master',
+        'sudo rm ./master.zip'
     ]
 
 }

--- a/autopilot/setup/scripts.py
+++ b/autopilot/setup/scripts.py
@@ -51,7 +51,7 @@ PILOT_ENV_CMDS = {
     'viz': [],
     'bluetooth':
         [
-            'sudo sed - i \'$s/$/\ndtoverlay=pi3-disable-bt/\' / boot / config.txt',
+            'sudo sed - i \'$s/$/\ndtoverlay=pi3-disable-bt/\' /boot/config.txt',
             'sudo systemctl disable hciuart.service',
             'sudo systemctl disable bluealsa.service',
             'sudo systemctl disable bluetooth.service'

--- a/autopilot/setup/setup_autopilot.py
+++ b/autopilot/setup/setup_autopilot.py
@@ -4,6 +4,7 @@ After initial setup, configure autopilot: create an autopilot directory and a pr
 """
 
 import npyscreen as nps
+import _curses
 from collections import OrderedDict as odict
 import pprint
 import json
@@ -511,8 +512,12 @@ if __name__ == "__main__":
     ###################################3
     # Run the npyscreen prompt
 
-    setup = Autopilot_Setup(prefs)
-    setup.run()
+    try:
+        setup = Autopilot_Setup(prefs)
+        setup.run()
+    except _curses.error as e:
+        print(f'Problem opening the Setup GUI!\nThis is most likely due to the window you are running the setup command in not being wide enough.\n\nError thrown:\n{e}')
+        sys.exit()
 
     ####################################
     # Collect values

--- a/autopilot/setup/setup_autopilot.py
+++ b/autopilot/setup/setup_autopilot.py
@@ -18,6 +18,7 @@ import importlib
 
 from autopilot import hardware
 from autopilot.setup.run_script import call_series, run_script, list_scripts
+from autopilot.setup.scripts import ENV_PILOT, PILOT_ENV_CMDS
 
 # CLI Options
 
@@ -28,28 +29,6 @@ parser.add_argument('-s', '--script', help="Run a setup script without entering 
 parser.add_argument('-l', '--list_scripts', help="list available setup scripts!", action='store_true')
 
 AGENTS = ('TERMINAL', 'PILOT', 'CHILD')
-
-
-ENV_PILOT = odict({
-    'env_pilot'   : {'type': 'bool',
-                     'text': 'install system packages necessary for autopilot? (required if they arent already)'},
-    'performance' : {'type': 'bool',
-                     'text': 'Do performance enhancements? (recommended, change cpu governor and give more memory to audio)'},
-    'change_pw': {'type': 'bool',
-                  'text': "If you haven't, you should change the default raspberry pi password or you _will_ get your identity stolen. Change it now?"},
-    'set_locale': {'type': 'bool',
-                   'text': 'Would you like to set your locale?'},
-    'hifiberry' : {'type': 'bool',
-                   'text': 'Setup Hifiberry DAC/AMP?'},
-    'viz'       : {'type': 'bool',
-                   'text': 'Install X11 server and psychopy for visual stimuli?'},
-    'bluetooth' : {'type': 'bool',
-                   'text': 'Disable Bluetooth? (recommended unless you\'re using it <3'},
-    'systemd'   : {'type': 'bool',
-                   'text': 'Install Autopilot as a systemd service?\nIf you are running this command in a virtual environment it will be used to launch Autopilot'},
-    'jackd'     : {'type': 'bool',
-                   'text': 'Install jack audio (required if AUDIOSERVER == jack)'}
-})
 
 BASE_PREFS = odict({
     'NAME'       : {'type': 'str', "text": "Agent Name:"},
@@ -102,101 +81,6 @@ DIRECTORY_STRUCTURE = {
     'PROTOCOLDIR': 'protocols',
 }
 
-PILOT_ENV_CMDS = {
-    'performance':
-        ['sudo systemctl disable raspi-config',
-         'sudo sed -i \'/^exit 0/i echo "performance" | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor\' /etc/rc.local',
-         'sudo sh -c "echo @audio - memlock 256000 >> /etc/security/limits.conf"',
-         'sudo sh -c "echo @audio - rtprio 75 >> /etc/security/limits.conf"',
-         ],
-    'performance_cameras':
-        [
-            "sudo sh -c 'echo options uvcvideo nodrop=1 timeout=10000 quirks=0x80 > /etc/modprobe.d/uvcvideo.conf'",
-            "sudo rmmod uvcvideo",
-            "sudo modprobe uvcvideo",
-            "sudo sed -i \"/^exit 0/i sudo sh -c 'echo ${usbfs_size} > /sys/module/usbcore/parameters/usbfs_memory_mb'\" /etc/rc.local"
-        ],
-    'change_pw': ['passwd'],
-    'set_locale': ['sudo dpkg-reconfigure locales',
-                   'sudo dpkg-reconfigure keyboard-configuration'],
-    'hifiberry':
-        [
-            {'command':'sudo adduser pi i2c', 'optional':True},
-            'sudo sed -i \'s/^dtparam=audio=on/#dtparam=audio=on/g\' /boot/config.txt',
-            'sudo sed -i \'$s/$/\\ndtoverlay=hifiberry-dacplus\\ndtoverlay=i2s-mmap\\ndtoverlay=i2c-mmap\\ndtparam=i2c1=on\\ndtparam=i2c_arm=on/\' /boot/config.txt',
-            'echo -e \'pcm.!default {\\n type hw card 0\\n}\\nctl.!default {\\n type hw card 0\\n}\' | sudo tee /etc/asound.conf'
-        ],
-    'viz': [],
-    'bluetooth':
-        [
-            'sudo sed - i \'$s/$/\ndtoverlay=pi3-disable-bt/\' / boot / config.txt',
-            'sudo systemctl disable hciuart.service',
-            'sudo systemctl disable bluealsa.service',
-            'sudo systemctl disable bluetooth.service'
-        ],
-    'jackd':
-        ['sudo apt update && sudo apt install -y jackd2'],
-    'jackd_source':
-        [
-            "git clone git://github.com/jackaudio/jack2 --depth 1",
-            "cd jack2",
-            "./waf configure --alsa=yes --libdir=/usr/lib/arm-linux-gnueabihf/",
-            "./waf build -j6",
-            "sudo ./waf install",
-            "sudo ldconfig",
-            "sudo sh -c \"echo @audio - memlock 256000 >> /etc/security/limits.conf\"",             # giving jack more juice
-            "sudo sh -c \"echo @audio - rtprio 75 >> /etc/security/limits.conf\"",
-            "cd ..",
-            "rm -rf ./jack2"
-        ],
-    'opencv':
-        [
-            "sudo apt-get install -y build-essential cmake ccache unzip pkg-config libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev ffmpeg libgtk-3-dev libcanberra-gtk* libatlas-base-dev gfortran python2-dev python-numpy",
-            "git clone https://github.com/opencv/opencv.git",
-            "git clone https://github.com/opencv/opencv_contrib",
-            "cd opencv",
-            "mkdir build",
-            "cd build",
-            "cmake -D CMAKE_BUILD_TYPE=RELEASE \
-                -D CMAKE_INSTALL_PREFIX=/usr/local \
-                -D OPENCV_EXTRA_MODULES_PATH=/home/pi/git/opencv_contrib/modules \
-                -D BUILD_TESTS=OFF \
-                -D BUILD_PERF_TESTS=OFF \
-                -D BUILD_DOCS=OFF \
-                -D WITH_TBB=ON \
-                -D CMAKE_CXX_FLAGS=\"-DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0\" \
-                -D WITH_OPENMP=ON \
-                -D WITH_IPP=OFF \
-                -D WITH_OPENCL=ON \
-                -D WITH_V4L=ON \
-                -D WITH_LIBV4L=ON \
-                -D ENABLE_NEON=ON \
-                -D ENABLE_VFPV3=ON \
-                -D PYTHON3_EXECUTABLE=/usr/bin/python3 \
-                -D PYTHON_INCLUDE_DIR=/usr/include/python3.7 \
-                -D PYTHON_INCLUDE_DIR2=/usr/include/arm-linux-gnueabihf/python3.7 \
-                -D OPENCV_ENABLE_NONFREE=ON \
-                -D INSTALL_PYTHON_EXAMPLES=OFF \
-                -D WITH_CAROTENE=ON \
-                -D CMAKE_SHARED_LINKER_FLAGS='-latomic' \
-                -D BUILD_EXAMPLES=OFF ..",
-            "sudo sed -i 's/^CONF_SWAPSIZE=100/CONF_SWAPSIZE=2048/g' /etc/dphys-swapfile", # increase size of swapfile so multicore build works
-            "sudo /etc/init.d/dphys-swapfile stop",
-            "sudo /etc/init.d/dphys-swapfile start",
-            "make -j4",
-            "sudo make install",
-            "sudo ldconfig",
-            "sudo sed -i 's/^CONF_SWAPSIZE=2048/CONF_SWAPSIZE=100/g' /etc/dphys-swapfile",
-            "sudo /etc/init.d/dphys-swapfile stop",
-            "sudo /etc/init.d/dphys-swapfile start"
-        ],
-    'env_pilot':
-        [
-            "sudo apt-get update",
-            "sudo apt-get install -y build-essential cmake git python3-dev libatlas-base-dev libsamplerate0-dev libsndfile1-dev libreadline-dev libasound-dev i2c-tools libportmidi-dev liblo-dev libhdf5-dev libzmq-dev libffi-dev",
-        ]
-
-}
 """
 performance: 
     * disable startup script that changes cpu governor,

--- a/autopilot/setup/setup_autopilot.py
+++ b/autopilot/setup/setup_autopilot.py
@@ -515,8 +515,17 @@ if __name__ == "__main__":
     try:
         setup = Autopilot_Setup(prefs)
         setup.run()
-    except _curses.error as e:
-        print(f'Problem opening the Setup GUI!\nThis is most likely due to the window you are running the setup command in not being wide enough.\n\nError thrown:\n{e}')
+    except (_curses.error, nps.wgwidget.NotEnoughSpaceForWidget) as e:
+        # get minimum column count
+        try:
+            min_cols = setup.getForm(setup.STARTING_FORM).min_c
+            print(f'Problem opening the Setup GUI!\nThis is most likely due to this window not being wide enough\n' + \
+                  'The minimum width for the setup GUI is:\n\033[0;32;40m' + \
+                  "-"*min_cols + '\u001b[0m\n\n' + f'Got error:\n{e}')
+
+        except:
+            print(f'Problem opening the Setup GUI!\nThis is most likely due to this window not being wide enough\n\nGot Error:\n{e}')
+
         sys.exit()
 
     ####################################

--- a/autopilot/setup/setup_autopilot.py
+++ b/autopilot/setup/setup_autopilot.py
@@ -17,7 +17,7 @@ import ast
 import importlib
 
 from autopilot import hardware
-from autopilot.setup.run_script import call_series, run_script, list_scripts=
+from autopilot.setup.run_script import call_series, run_script, list_scripts
 
 # CLI Options
 

--- a/autopilot/stim/managers.py
+++ b/autopilot/stim/managers.py
@@ -13,7 +13,7 @@ from collections import deque
 import numpy as np
 from autopilot import prefs
 if prefs.AGENT.upper() == 'PILOT':
-    if 'AUDIO' in prefs.CONFIG:
+    if 'AUDIO' in prefs.CONFIG or prefs.AUDIOSERVER is not None:
         from autopilot.stim.sound import sounds
         # TODO be loud about trying to init sounds when not in config
 

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -474,7 +474,7 @@ if server_type in ("jack", "docs", True):
             while not self.quitting.is_set():
                 try:
                     #self.continuous_q.put(self.continuous_cycle.next(), timeout=wait_time)
-                    self.continuous_q.put_nowait(self.continuous_cycle.next())
+                    self.continuous_q.put_nowait(next(self.continuous_cycle))
                 except Full:
                     pass
             # for chunk in self.chunks:

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -49,7 +49,10 @@ from autopilot import prefs
 
 # switch behavior based on audio server type
 try:
-    server_type = prefs.AUDIOSERVER.lower()
+    if isinstance(prefs.AUDIOSERVER, str):
+        server_type = prefs.AUDIOSERVER.lower()
+    else:
+        server_type = prefs.AUDIOSERVER
 except:
 #    # TODO: The 'attribute don't exist' type - i think NameError?
     server_type = None

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -121,6 +121,8 @@ if server_type in ("pyo", "docs"):
 
 
 if server_type in ("jack", "docs", True):
+    if server_type is True:
+        server_type = "jack"
     from autopilot.stim.sound import jackclient
 
     class Jack_Sound(object):

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -294,7 +294,7 @@ if server_type in ("jack", "docs", True):
             """
 
             if hasattr(self, 'path'):
-                self.logger.info('BUFFERING SOUND {}'.format(self.path))
+                self.logger.debug('BUFFERING SOUND {}'.format(self.path))
 
             if not self.initialized and not self.table:
                 try:
@@ -395,7 +395,7 @@ if server_type in ("jack", "docs", True):
                 self.buffer()
 
             if hasattr(self, 'path'):
-                self.logger.info('PLAYING SOUND {}'.format(self.path))
+                self.logger.debug('PLAYING SOUND {}'.format(self.path))
 
             self.play_evt.set()
             self.stop_evt.clear()
@@ -480,11 +480,6 @@ if server_type in ("jack", "docs", True):
             # for chunk in self.chunks:
             #     self.continuous_q.put_nowait(chunk)
 
-
-
-
-
-
         def stop_continuous(self):
             """
             Stop playing a continuous sound
@@ -492,7 +487,7 @@ if server_type in ("jack", "docs", True):
             Should be merged into a general stop method
             """
             if not self.continuous:
-                Warning("Not a continous sound!")
+                self.logger.warning("stop_continuous called but not a continuous sound!")
                 return
 
             self.quitting.set()

--- a/autopilot/tasks/free_water.py
+++ b/autopilot/tasks/free_water.py
@@ -179,8 +179,6 @@ class Free_Water(Task):
         """
         for k, v in self.hardware.items():
             for pin, obj in v.items():
-                if k == "LEDS":
-                    obj.set_color([0,0,0])
                 obj.release()
 
 

--- a/autopilot/tasks/nafc.py
+++ b/autopilot/tasks/nafc.py
@@ -476,12 +476,14 @@ class Nafc_Gap(Nafc):
         kwargs['stim_light'] = False
         super(Nafc_Gap, self).__init__(**kwargs)
 
+        self.logger.debug('starting background sound')
         self.noise_amplitude = noise_amplitude
         self.noise_duration = 10*1000 # 10 seconds
         self.noise = sounds.Noise(duration=self.noise_duration,
                                   amplitude=self.noise_amplitude)
 
         self.noise.play_continuous()
+        self.logger.debug('background sound started')
 
 
     def end(self):

--- a/autopilot/tasks/nafc.py
+++ b/autopilot/tasks/nafc.py
@@ -287,7 +287,12 @@ class Nafc(Task):
             change_to_blue = lambda: self.hardware['LEDS']['C'].set([0, 0, 255])
             self.triggers['C'].append(change_to_blue)
         else:
-            turn_off = lambda: self.hardware['LEDS']['C'].set([0,0,0])
+            # just turn the center light off and side lights on immediately.
+            turn_off = lambda: self.set_leds({
+                'L': [0,255,0],
+                'R': [0,255,0]
+            })
+            #turn_off = lambda: self.hardware['LEDS']['C'].set([0,0,0])
             self.triggers['C'].append(turn_off)
 
         if self.req_reward:

--- a/autopilot/tasks/nafc.py
+++ b/autopilot/tasks/nafc.py
@@ -458,7 +458,8 @@ class Nafc(Task):
         flash lights for punish_dir
         """
         for k, v in self.hardware['LEDS'].items():
-            v.flash(self.punish_dur)
+            if isinstance(v, gpio.LED_RGB):
+                v.flash(self.punish_dur)
 
 class Nafc_Gap(Nafc):
     PARAMS = copy(Nafc.PARAMS)

--- a/autopilot/tasks/nafc.py
+++ b/autopilot/tasks/nafc.py
@@ -198,6 +198,7 @@ class Nafc(Task):
 
         # Initialize hardware
         self.init_hardware()
+        self.logger.debug('Hardware initialized')
 
         # Set reward values for solenoids
         # TODO: Super inelegant, implement better with reward manager
@@ -221,6 +222,7 @@ class Nafc(Task):
         if bias_mode:
             self.stim_manager.do_bias(mode=self.bias_mode,
                                       thresh=self.bias_threshold)
+        self.logger.debug('Stimulus manager initialized')
 
         # If we aren't passed an event handler
         # (used to signal that a trigger has been tripped),
@@ -556,6 +558,7 @@ class Nafc_Gap_Laser(Nafc_Gap):
 
         self.duration_ids = []
 
+        self.logger.debug('Creating laser and LED series')
         if isinstance(self.laser_durations, list):
             # iterate through durations and create lists for each
             for duration in self.laser_durations:
@@ -582,7 +585,7 @@ class Nafc_Gap_Laser(Nafc_Gap):
             # use the durations of the stimuli
             self.logger.exception('reading durations from stimulus manager not implemented')
             raise NotImplementedError('read durations from the stimulus manager')
-
+        self.logger.debug('Laser series created')
         # -----------------------------------
         # create a pulse for the LED that's equal to the longest stimulus duration
         # use find_recursive to find all durations
@@ -590,7 +593,7 @@ class Nafc_Gap_Laser(Nafc_Gap):
         stim_durations = list(find_recursive('duration', kwargs['stim']))
         max_duration = np.max(stim_durations)
         self.hardware['LEDS']['TOP'].store_series('on', values=1, durations=max_duration )
-
+        self.logger.debug('LED series created')
 
     def request(self,*args,**kwargs):
         # call the super method

--- a/autopilot/tasks/nafc.py
+++ b/autopilot/tasks/nafc.py
@@ -511,8 +511,7 @@ class Nafc_Gap_Laser(Nafc_Gap):
     HARDWARE = copy(Nafc_Gap.HARDWARE)
 
     HARDWARE['LASERS'] = {
-        'L': gpio.Digital_Out,
-        'R': gpio.Digital_Out
+        'LR': gpio.Digital_Out
     }
 
     HARDWARE['LEDS']['TOP'] = gpio.Digital_Out

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -151,7 +151,7 @@ class Task(object):
                         hw = handler(hw_args, name=hw_name)
 
                     # if a pin is a trigger pin (event-based input), give it the trigger handler
-                    if hw.trigger:
+                    if hw.is_trigger:
                         hw.assign_cb(self.handle_trigger)
 
                     # add to forward and backwards pin dicts

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -311,7 +311,8 @@ class Task(object):
         flash lights for punish_dir
         """
         for k, v in self.hardware['LEDS'].items():
-            v.flash(self.punish_dur)
+            if v.__module__ == "autopilot.hardware.gpio" and type(v).__name__ == "LED_RGB":
+                v.flash(self.punish_dur)
 
     def end(self):
         """

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -3,7 +3,7 @@
 #!/usr/bin/python2.7
 from collections import OrderedDict as odict
 import threading
-import datetime
+from datetime import datetime
 import os
 import logging
 import tables

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -1,6 +1,4 @@
 # Base class for tasks
-
-#!/usr/bin/python2.7
 from collections import OrderedDict as odict
 import threading
 from datetime import datetime

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -113,6 +113,7 @@ class Task(object):
 
         # try to get logger
         self.logger = logging.getLogger('main')
+        self.logger.debug('Task Metaclass initialized')
 
 
 

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -3,6 +3,8 @@
 #!/usr/bin/python2.7
 from collections import OrderedDict as odict
 import threading
+import datetime
+import os
 import logging
 import tables
 # from autopilot.core.networking import Net_Node
@@ -112,7 +114,7 @@ class Task(object):
         #self.running = threading.Event()
 
         # try to get logger
-        self.logger = logging.getLogger('main')
+        self.init_logging()
         self.logger.debug('Task Metaclass initialized')
 
 
@@ -166,6 +168,27 @@ class Task(object):
                 except:
                     self.logger.exception("Pin could not be instantiated - Type: {}, Pin: {}".format(type, pin))
 
+    def init_logging(self):
+        """
+        Initialize logging to a timestamped file in `prefs.LOGDIR` .
+
+        The logger name will be `'node.{id}'` .
+        """
+        #FIXME: Just copying and pasting from net node, should implement logging uniformly across hw objects
+        timestr = datetime.now().strftime('%y%m%d_%H%M%S')
+        log_file = os.path.join(prefs.LOGDIR, '{}_{}.log'.format(self.__class__, timestr))
+
+        self.logger = logging.getLogger('task.{}'.format(self.__class__))
+        self.log_handler = logging.FileHandler(log_file)
+        self.log_formatter = logging.Formatter("%(asctime)s %(levelname)s : %(message)s")
+        self.log_handler.setFormatter(self.log_formatter)
+        self.logger.addHandler(self.log_handler)
+        if hasattr(prefs, 'LOGLEVEL'):
+            loglevel = getattr(logging, prefs.LOGLEVEL)
+        else:
+            loglevel = logging.WARNING
+        self.logger.setLevel(loglevel)
+        self.logger.info('{} Logging Initiated'.format(self.__class__))
 
     def set_reward(self, vol=None, duration=None, port=None):
         """

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -281,7 +281,7 @@ class Task(object):
             if k in color_dict.keys():
                 v.set(color_dict[k])
             else:
-                v.set([0,0,0])
+                v.set(0)
 
     def flash_leds(self):
         """

--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -201,9 +201,9 @@ class Task(object):
                 only set `port`
         """
         if not vol and not duration:
-            Exception("Need to have duration or volume!!")
+            raise Exception("Need to have duration or volume!!")
         if vol and duration:
-            Warning('given both volume and duration, using volume.')
+            self.logger.warning('given both volume and duration, using volume.')
 
         if not port:
             for k, port in self.hardware['PORTS'].items():
@@ -211,7 +211,7 @@ class Task(object):
                     try:
                         port.dur_from_vol(vol)
                     except AttributeError:
-                        Warning('No calibration found, using duration = 20ms instead')
+                        self.logger.warning('No calibration found, using duration = 20ms instead')
                         port.duration = 0.02
                 else:
                     port.duration = float(duration)/1000.
@@ -221,13 +221,13 @@ class Task(object):
                     try:
                         self.hardware['PORTS'][port].dur_from_vol(vol)
                     except AttributeError:
-                        Warning('No calibration found, using duration = 20ms instead')
+                        self.logger.warning('No calibration found, using duration = 20ms instead')
                         port.duration = 0.02
 
                 else:
                     self.hardware['PORTS'][port].duration = float(duration) / 1000.
             except KeyError:
-                Exception('No port found named {}'.format(port))
+                raise Exception('No port found named {}'.format(port))
 
     # def init_sound(self):
     #     pass

--- a/docs/changelog/v0.3.0.rst
+++ b/docs/changelog/v0.3.0.rst
@@ -1,5 +1,40 @@
 .. _changelog_v030:
 
+v0.3.3 (October 25, 2020)
+--------------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix layout in batch reassign gui widget from python 3 float division
+* Cleaner close by catching KeyboardInterrupt in networking modules
+* Fixing audioserver boot options -- if 'AUDIOSERVER' is set even if 'AUDIO' isn't set in prefs, should still start server. Not full fixed, need to make single plugin handler, single point of enabling/disabling optional services like audio server
+* Fix conflict between polarity and pull in initializing `pulls` in pilot
+* Catch ``tables.HDF5ExtError`` if local .h5 file corrupt in pilot
+* For some reason 'fs' wasn't being replaced in the jackd string, reinstated.
+* Fix comparison in LED_RGB that caused '0' to turn on full becuse 'value' was being checked for its truth value (0 is false) rather than checking if value is None.
+* ``obj.next()`` to ``next(obj)``` in jackdserver
+
+Improvements
+~~~~~~~~~~~~~
+
+* Better internal handling of pigpiod -- you're now able to import and use hardware modules without needing to explicitly start pigpiod!!
+* Hopefully better killing of processes on exit, though still should work into unified process manager so don't need to reimplement everything (eg. as is done with launching pigpiod and jackd)
+* Environment scripts have been split out into ``setup/scripts.py`` and you can now run them with ``python -m autopilot.setup.run_script`` (use ``--help`` to see how!)
+* Informative error when setup is run with too narrow terminal: https://github.com/wehr-lab/autopilot/issues/23
+* More loggers, but increased need to unify logger creation!!!
+
+
+Cleanup
+~~~~~~~~
+
+* remove unused imports in main ``__init__.py`` that made cyclical imports happen more frequently than necessary
+* single-sourcing version number from ``__init__.py``
+* more cleanup of unnecessary meta and header stuff left from early days
+* more debugging flags
+* filter ``NaturalNameWarning`` from pytables
+* quieter cleanups for hardware objects
+
 v0.3.2 (September 28, 2020)
 -----------------------------
 

--- a/docs/guide.installation.rst
+++ b/docs/guide.installation.rst
@@ -66,6 +66,12 @@ and developing directly in the library so your gorgeous insights can be integrat
 Configuration
 ==============
 
+.. note::
+
+    If you didn't install the system dependencies yet, you can do so now with ::
+
+        python3 -m autopilot.setup.run_script env_pilot
+
 After installation, set Autopilot up!
 
 The setup routine will

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -310,6 +310,11 @@ Bugs
 * Network connectivity can be lost if the network hardware is disturbed (in our case the router gets kicked
   from the network it is connected to) and is only reliably recovered by restarting the system. Network connections
   should be able to recover disturbance.
+* The use of `off` and `on` is inconsistent between :class:`.Digital_Out` and :class:`.PWM` -- since the PWM
+  cleans values (inverts logic, expands range),
+* There is ambiguity in setting PWM ranges: using :meth:`.PWM.set` with 0-1 uses the whole range off to on, but
+  numbers from 0-:attr:`.PWM.range` can be used as well -- 0-1 is the preferred behavior, but should using
+  0-range still be supported as well?
 
 
 Completed

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -288,6 +288,9 @@ Improvements
     * Networking modules and other thread-creating modules should probably create thread pools to avoid
       the overhead of constantly spawning them
 
+* **Decorators** - specific improvements to make autopilot objects magic!
+
+    * :mod:`.hardware.gpio` - try/catch release decorator so don't have to check for attribute error in every subclass!
 
 
 Bugs

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import platform
 import os
+import codecs
 
 #from skbuild import setup, constants
 from setuptools import find_packages, setup
@@ -90,9 +91,31 @@ with open(os.path.join(
         'README.md'), 'r') as readme_f:
     readme = readme_f.read()
 
+
+# get package version
+def read(rel_path):
+    """
+    https://packaging.python.org/guides/single-sourcing-package-version/
+    """
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    """
+    https://packaging.python.org/guides/single-sourcing-package-version/
+    """
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 setup(
     name="auto-pi-lot",
-    version="0.3.2",
+    version=get_version('autopilot/__init__.py'),
     description="Distributed behavioral experiments",
     long_description = readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     long_description = readme,
     long_description_content_type='text/markdown',
     author="Jonny Saunders",
-    author_email="sneakers-the-rat@protonmail.com",
+    author_email="j@nny.fyi",
     url="https://auto-pi-lot.com",
     license="MPL-2.0",
     scripts = SCRIPTS,


### PR DESCRIPTION
Bugfixes
* Fix layout in batch reassign from python 3 float division
* Cleaner close by catching KeyboardInterrupt in networking modules
* Fixing audioserver boot options -- if 'AUDIOSERVER' is set even if 'AUDIO' isn't set in prefs, should still start server. Not full fixed, need to make single plugin handler, single point of enabling/disabling optional services like audio server
* Fix conflict between polarity and pull in initializing `pulls` in pilot
* Catch `tables.HDF5ExtError` if local .h5 file corrupt in pilot
* For some reason 'fs' wasn't being replaced in the jackd string, reinstated.
* Fix comparison in LED_RGB that caused '0' to turn on full becuse 'value' was being checked for its truth value (0 is false) rather than checking if value is None. 
* `obj.next()` to `next(obj)` in jackdserver


Improvements
* Better internal handling of pigpiod -- you're now able to import and use hardware modules without needing to explicitly start pigpiod!!
* Hopefully better killing of processes on exit, though still should work into unified process manager so don't need to reimplement everything (eg. as is done with launching pigpiod and jackd)
* Environment scripts have been split out into `setup/scripts.py` and you can now run them with `python -m autopilot.setup.run_script` (use `--help` to see how!) 
* Informative error when setup is run with too narrow terminal: https://github.com/wehr-lab/autopilot/issues/23
* More loggers, but increased need to unify logger creation!!!


Cleanup
* remove unused imports in main `__init__.py` that made cyclical imports happen more frequently than necessary
* single-sourcing version number from `__init__.py`
* more cleanup of unnecessary meta and header stuff left from early days
* more debugging flags
* filter `NaturalNameWarning` from pytables
* quieter cleanups for hardware objects