### PR TITLE
fix user install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import find_packages, setup
 import subprocess
 import sys
 
+# fix user install issue
+import site
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 # declare defaults
 IS_RASPI = False


### PR DESCRIPTION
Hi Jonny, a simple fix to get an editable autopilot installation. 'pip3 install -e .' results in "WARNING: The user site-packages directory is disabled. error: can't create or remove files in install directory". This now works with 'pip3 install --user -e .' (no sudo required).