### PR TITLE
fix: set_duration and Solenoid.duration are both in ms, no conversion…

### DIFF
--- a/autopilot/tasks/task.py
+++ b/autopilot/tasks/task.py
@@ -182,9 +182,9 @@ class Task(object):
                         port.dur_from_vol(vol)
                     except AttributeError:
                         self.logger.warning('No calibration found, using duration = 20ms instead')
-                        port.duration = 0.02
+                        port.duration = 20.0
                 else:
-                    port.duration = float(duration)/1000.
+                    port.duration = float(duration)
         else:
             try:
                 if vol:
@@ -192,10 +192,10 @@ class Task(object):
                         self.hardware['PORTS'][port].dur_from_vol(vol)
                     except AttributeError:
                         self.logger.warning('No calibration found, using duration = 20ms instead')
-                        port.duration = 0.02
+                        port.duration = 20.0
 
                 else:
-                    self.hardware['PORTS'][port].duration = float(duration) / 1000.
+                    self.hardware['PORTS'][port].duration = float(duration)
             except KeyError:
                 raise Exception('No port found named {}'.format(port))
 


### PR DESCRIPTION
This fixes an instance of ye olde second/millisecond conversion error. Both Solenoid.duration and Task.set_duration already operate only in millisecond, yet previous defaults were "0.020" and defaulted to miniscule reward sizes.

PS - LMK if PRs should be made against master instead of dev, or what you prefer in general