### PR TITLE
Let terminal GUI remember its previous size (depending on a new pref)

### DIFF
--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -1,16 +1,15 @@
+"""Methods for running the Terminal GUI"""
+
 import argparse
 import json
 import sys
 import os
-
 import datetime
 import logging
 import threading
 from collections import OrderedDict as odict
 import numpy as np
-
 from PySide2 import QtCore, QtGui, QtSvg, QtWidgets
-
 from autopilot import prefs
 from autopilot.core import styles
 
@@ -35,8 +34,6 @@ if __name__ == '__main__':
     # init prefs for module access
     prefs.init(prefs_file)
 
-
-
 from autopilot.core.subject import Subject
 from autopilot.core.plots import Plot_Widget
 from autopilot.core.networking import Terminal_Station, Net_Node
@@ -44,7 +41,7 @@ from autopilot.core.utils import InvokeEvent, Invoker, get_invoker
 from autopilot.core.gui import Control_Panel, Protocol_Wizard, Weights, Reassign, Calibrate_Water, Bandwidth_Test
 from autopilot.core.loggers import init_logger
 
-
+# Try to import viz, but continue if that doesn't work
 IMPORTED_VIZ = False
 VIZ_ERROR = None
 try:
@@ -192,9 +189,6 @@ class Terminal(QtWidgets.QMainWindow):
         #self.heartbeat(once=True)
         self.logger.info('Terminal Initialized')
 
-
-
-
     def initUI(self):
         """
         Initializes graphical elements of Terminal.
@@ -205,13 +199,9 @@ class Terminal(QtWidgets.QMainWindow):
         * :class:`.gui.Control_Panel`
         * :class:`.plots.Plot_Widget`
         """
-
-
         # set central widget
         self.widget = QtWidgets.QWidget()
         self.setCentralWidget(self.widget)
-
-
 
         # Start GUI
         self.layout = QtWidgets.QGridLayout()
@@ -279,8 +269,6 @@ class Terminal(QtWidgets.QMainWindow):
         self.data_panel = Plot_Widget()
         self.data_panel.init_plots(self.pilots.keys())
 
-
-
         # Logo goes up top
         # https://stackoverflow.com/questions/25671275/pyside-how-to-set-an-svg-icon-in-qtreewidgets-item-and-change-the-size-of-the
 
@@ -326,7 +314,7 @@ class Terminal(QtWidgets.QMainWindow):
         # want to subtract bounding title box, our title bar, and logo height.
         # our y offset will be the size of the bounding title box
 
-        # Then our tilebar
+        # Then our titlebar
         # multiply by three to get the inner (file, etc.) bar, the top bar (min, maximize, etc)
         # and then the very top system tray bar in ubuntu
         #titleBarHeight = self.style().pixelMetric(QtWidgets.QStyle.PM_TitleBarHeight,
@@ -336,8 +324,6 @@ class Terminal(QtWidgets.QMainWindow):
         #titleBarHeight = bar_height*2
         # finally our logo
         logo_height = bar_height
-
-
 
         winheight = winsize.height() - title_bar_height - logo_height  # also subtract logo height
         winsize.setHeight(winheight)
@@ -398,7 +384,6 @@ class Terminal(QtWidgets.QMainWindow):
             self.heartbeat_timer = threading.Timer(self.heartbeat_dur, self.heartbeat)
             self.heartbeat_timer.daemon = True
             self.heartbeat_timer.start()
-
 
     def toggle_start(self, starting, pilot, subject=None):
         """Start or Stop running the currently selected subject's task. Sends a
@@ -528,11 +513,6 @@ class Terminal(QtWidgets.QMainWindow):
             elif value['state'] != self.pilots[value['pilot']]['state']:
                 #self.control_panel.panels[value['pilot']].button.set_state(value['state'])
                 self.pilots[value['pilot']]['state'] = value['state']
-
-            
-
-
-
 
     def l_handshake(self, value):
         """
@@ -721,7 +701,6 @@ class Terminal(QtWidgets.QMainWindow):
 
         return subjects_protocols
 
-
     def reassign_protocols(self):
         """
         Batch reassign protocols and steps.
@@ -830,8 +809,6 @@ class Terminal(QtWidgets.QMainWindow):
         if psychometric_dialog.result() != 1:
             return
 
-
-
         chart = viz.plot_psychometric(psychometric_dialog.plot_params)
 
         text, ok = QtGui.QInputDialog.getText(self, 'save plot?', 'what to call this thing')
@@ -841,26 +818,8 @@ class Terminal(QtWidgets.QMainWindow):
 
         #chart.serve()
 
-
-
-
-
             #viz.plot_psychometric(self.subjects_protocols)
         #result = psychometric_dialog.exec_()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def closeEvent(self, event):
         """
@@ -884,15 +843,11 @@ class Terminal(QtWidgets.QMainWindow):
 
         event.accept()
 
+# Create the QApplication and run it
+# Prefs were already loaded at the very top
 if __name__ == "__main__":
-
-    #with open(prefs_file) as prefs_file_open:
-    #    prefs = json.load(prefs_file_open)
-
     app = QtWidgets.QApplication(sys.argv)
     #app.setGraphicsSystem("opengl")
     app.setStyle('GTK+') # Keeps some GTK errors at bay
     ex = Terminal()
     sys.exit(app.exec_())
-
-

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -199,36 +199,38 @@ class Terminal(QtWidgets.QMainWindow):
         * :class:`.gui.Control_Panel`
         * :class:`.plots.Plot_Widget`
         """
-        # set central widget
+        # Set central widget
         self.widget = QtWidgets.QWidget()
         self.setCentralWidget(self.widget)
 
-        # Start GUI
+        # Set the layout
         self.layout = QtWidgets.QGridLayout()
         self.layout.setSpacing(0)
         self.layout.setContentsMargins(0,0,0,0)
         self.widget.setLayout(self.layout)
 
+        # Set title
         self.setWindowTitle('Terminal')
         #self.menuBar().setFixedHeight(40)
 
-        # Main panel layout
-        #self.panel_layout.setContentsMargins(0,0,0,0)
-
-        # Init toolbar
-        # File menu
-        # make menu take up 1/10 of the screen
+        # Get the window size
         winsize = app.desktop().availableGeometry()
 
+        
+        ## Initalize the menuBar
+        # Linux: Set the menuBar to a fixed height
+        # Darwin: Don't worry about menuBar
         if sys.platform == 'darwin':
             bar_height = 0
         else:
             bar_height = (winsize.height()/30)+5
             self.menuBar().setFixedHeight(bar_height)
 
-
+        # Create a File menu
         self.file_menu = self.menuBar().addMenu("&File")
         self.file_menu.setObjectName("file")
+        
+        # Add "New Pilot" and "New Protocol" actions to File menu
         new_pilot_act = QtWidgets.QAction("New &Pilot", self, triggered=self.new_pilot)
         new_prot_act  = QtWidgets.QAction("New Pro&tocol", self, triggered=self.new_protocol)
         #batch_create_subjects = QtWidgets.QAction("Batch &Create subjects", self, triggered=self.batch_subjects)
@@ -237,8 +239,10 @@ class Terminal(QtWidgets.QMainWindow):
         self.file_menu.addAction(new_prot_act)
         #self.file_menu.addAction(batch_create_subjects)
 
-        # Tools menu
+        # Create a Tools menu
         self.tool_menu = self.menuBar().addMenu("&Tools")
+        
+        # Add actions to Tools menu
         subject_weights_act = QtWidgets.QAction("View Subject &Weights", self, triggered=self.subject_weights)
         update_protocol_act = QtWidgets.QAction("Update Protocols", self, triggered=self.update_protocols)
         reassign_act = QtWidgets.QAction("Batch Reassign Protocols", self, triggered=self.reassign_protocols)
@@ -248,12 +252,12 @@ class Terminal(QtWidgets.QMainWindow):
         self.tool_menu.addAction(reassign_act)
         self.tool_menu.addAction(calibrate_act)
 
-        # Plots menu
+        # Create a Plots menu and add Psychometric Curve action
         self.plots_menu = self.menuBar().addMenu("&Plots")
         psychometric = QtGui.QAction("Psychometric Curve", self, triggered=self.plot_psychometric)
         self.plots_menu.addAction(psychometric)
 
-        # Tests menu
+        # Create a Tests menu and add a Test Bandwidth action
         self.tests_menu = self.menuBar().addMenu("Test&s")
         bandwidth_test_act = QtWidgets.QAction("Test Bandwidth", self, triggered=self.test_bandwidth)
         self.tests_menu.addAction(bandwidth_test_act)
@@ -297,13 +301,16 @@ class Terminal(QtWidgets.QMainWindow):
             self.menuBar().adjustSize()
 
         #self.logo.load(pixmap_path)
-        # Combine all in main layout
+        
+        # Add Control Panel and Data Panel to main layout
         #self.layout.addWidget(self.logo, 0,0,1,2)
         self.layout.addWidget(self.control_panel, 0,0,1,1)
         self.layout.addWidget(self.data_panel, 0,1,1,1)
         self.layout.setColumnStretch(0, 1)
         self.layout.setColumnStretch(1, 3)
 
+        
+        ## Set window size
         # Set size of window to be fullscreen without maximization
         # Until a better solution is found, if not set large enough, the pilot tabs will
         # expand into infinity. See the Expandable_Tabs class
@@ -342,12 +349,16 @@ class Terminal(QtWidgets.QMainWindow):
         self.control_panel.setMaximumHeight(winheight)
         self.data_panel.setMaximumHeight(winheight)
 
+    
+        ## Finalize some aesthetics
         # set stylesheet for main window
         self.setStyleSheet(styles.TERMINAL)
 
         # set fonts to antialias
         self.setFont(self.font().setStyleStrategy(QtGui.QFont.PreferAntialias))
 
+
+        ## Show, and log that initialization is complete
         self.show()
         logging.info('UI Initialized')
 

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -214,7 +214,7 @@ class Terminal(QtWidgets.QMainWindow):
         #self.menuBar().setFixedHeight(40)
 
         # Get the window size
-        winsize = app.desktop().availableGeometry()
+        winsize = app.primaryScreen().availableGeometry()
 
         
         ## Initalize the menuBar
@@ -315,8 +315,8 @@ class Terminal(QtWidgets.QMainWindow):
         # Until a better solution is found, if not set large enough, the pilot tabs will
         # expand into infinity. See the Expandable_Tabs class
         #pdb.set_trace()
-        screensize = app.desktop().screenGeometry()
-        winsize = app.desktop().availableGeometry()
+        screensize = app.primaryScreen().size()
+        winsize = app.primaryScreen().availableGeometry()
 
         # want to subtract bounding title box, our title bar, and logo height.
         # our y offset will be the size of the bounding title box
@@ -342,7 +342,7 @@ class Terminal(QtWidgets.QMainWindow):
 
 
         # move to primary display and show maximized
-        primary_display = app.desktop().availableGeometry(0)
+        primary_display = app.primaryScreen().availableGeometry()
         self.move(primary_display.left(), primary_display.top())
         # self.resize(primary_display.width(), primary_display.height())
         #

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -294,27 +294,10 @@ class Terminal(QtWidgets.QMainWindow):
         # window manager reserved areas such as task bars and system menus.
         winsize = app.primaryScreen().availableGeometry()
 
-        # The difference in height between the two is the vertical height
-        # reserved by the window manager
-        title_bar_height = screensize.height()-winsize.height()
-
-        # for some reason logo_height is hardcoded as bar_height, which is 
-        # currently set equal to 0 on Darwin and 1/30 of winheight otherwise
-        logo_height = bar_height
-
-        # We will set the width of Terminal to match winsize width.
-        # And we set the height of Terminal to match winsize height, minus 
-        # title_bar_height and logo_height
-        winheight = winsize.height() - title_bar_height - logo_height  # also subtract logo height
-        winsize.setHeight(winheight)
-        
-        # Save this as max_height
-        self.max_height = winheight
-        
         # Now actually apply winsize to self.setGeometry
         self.setGeometry(winsize)
         
-        # Set a maximum size policy
+        # Set SizePolicy to maximum
         self.setSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum)
 
 
@@ -323,8 +306,8 @@ class Terminal(QtWidgets.QMainWindow):
         self.move(primary_display.left(), primary_display.top())
 
         # Also set the maximum height of each panel
-        self.control_panel.setMaximumHeight(winheight)
-        self.data_panel.setMaximumHeight(winheight)
+        self.control_panel.setMaximumHeight(winsize.height())
+        self.data_panel.setMaximumHeight(winsize.height())
 
     
         ## Finalize some aesthetics

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -311,41 +311,42 @@ class Terminal(QtWidgets.QMainWindow):
 
         
         ## Set window size
-        # Set size of window to be fullscreen without maximization
-        # Until a better solution is found, if not set large enough, the pilot tabs will
-        # expand into infinity. See the Expandable_Tabs class
-        #pdb.set_trace()
+        # This is the pixel resolution of the entire screen 
         screensize = app.primaryScreen().size()
+        
+        # This is the available geometry of the primary screen, excluding
+        # window manager reserved areas such as task bars and system menus.
         winsize = app.primaryScreen().availableGeometry()
 
-        # want to subtract bounding title box, our title bar, and logo height.
-        # our y offset will be the size of the bounding title box
-
-        # Then our titlebar
-        # multiply by three to get the inner (file, etc.) bar, the top bar (min, maximize, etc)
-        # and then the very top system tray bar in ubuntu
-        #titleBarHeight = self.style().pixelMetric(QtWidgets.QStyle.PM_TitleBarHeight,
-        #                                          QtWidgets.QStyleOptionTitleBar(), self) * 3
+        # The difference in height between the two is the vertical height
+        # reserved by the window manager
         title_bar_height = screensize.height()-winsize.height()
 
-        #titleBarHeight = bar_height*2
-        # finally our logo
+        # for some reason logo_height is hardcoded as bar_height, which is 
+        # currently set equal to 0 on Darwin and 1/30 of winheight otherwise
         logo_height = bar_height
 
+        # We will set the width of Terminal to match winsize width.
+        # And we set the height of Terminal to match winsize height, minus 
+        # title_bar_height and logo_height
         winheight = winsize.height() - title_bar_height - logo_height  # also subtract logo height
         winsize.setHeight(winheight)
+        
+        # Save this as max_height
         self.max_height = winheight
+        
+        # Now actually apply winsize to self.setGeometry
         self.setGeometry(winsize)
+        
+        # Set a maximum size policy
         self.setSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum)
 
-        # Set heights on control panel and data panel
 
-
-        # move to primary display and show maximized
+        ## Move to primary display and show maximized
         primary_display = app.primaryScreen().availableGeometry()
         self.move(primary_display.left(), primary_display.top())
-        # self.resize(primary_display.width(), primary_display.height())
-        #
+
+        # Also set the maximum height of each panel
         self.control_panel.setMaximumHeight(winheight)
         self.data_panel.setMaximumHeight(winheight)
 

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -273,35 +273,11 @@ class Terminal(QtWidgets.QMainWindow):
         self.data_panel = Plot_Widget()
         self.data_panel.init_plots(self.pilots.keys())
 
-        # Logo goes up top
-        # https://stackoverflow.com/questions/25671275/pyside-how-to-set-an-svg-icon-in-qtreewidgets-item-and-change-the-size-of-the
-
-        #
-        # pixmap_path = os.path.join(os.path.dirname(prefs.get('AUTOPILOT_ROOT')), 'graphics', 'autopilot_logo_small.svg')
-        # #svg_renderer = QtSvg.QSvgRenderer(pixmap_path)
-        # #image = QtWidgets.QImage()
-        # #self.logo = QtSvg.QSvgWidget()
-        #
-        #
-        # # set size, preserving aspect ratio
-        # logo_height = round(44.0*((bar_height-5)/44.0))
-        # logo_width = round(139*((bar_height-5)/44.0))
-        #
-        # svg_renderer = QtSvg.QSvgRenderer(pixmap_path)
-        # image = QtGui.QImage(logo_width, logo_height, QtGui.QImage.Format_ARGB32)
-        # # Set the ARGB to 0 to prevent rendering artifacts
-        # image.fill(0x00000000)
-        # svg_renderer.render(QtGui.QPainter(image))
-        # pixmap = QtGui.QPixmap.fromImage(image)
-        # self.logo = QtWidgets.QLabel()
-        # self.logo.setPixmap(pixmap)
-
+        # Set logo to corner widget
         if sys.platform != 'darwin':
             self.menuBar().setCornerWidget(self.logo, QtCore.Qt.TopRightCorner)
             self.menuBar().adjustSize()
 
-        #self.logo.load(pixmap_path)
-        
         # Add Control Panel and Data Panel to main layout
         #self.layout.addWidget(self.logo, 0,0,1,2)
         self.layout.addWidget(self.control_panel, 0,0,1,1)

--- a/autopilot/prefs.py
+++ b/autopilot/prefs.py
@@ -282,6 +282,15 @@ _DEFAULTS = odict({
         "default": str(_basedir / "pilot_db.json"),
         "scope": Scopes.TERMINAL
     },
+    'TERMINAL_WINSIZE_BEHAVIOR': {
+        'type': 'str',
+        'text': (
+            'How the Terminal window is sized: '
+            '"maximum", "moderate", or "remember"'
+            ),
+        'default': 'moderate',
+        "scope": Scopes.TERMINAL    
+    },    
     'LINEAGE': {
         'type': 'choice',
         "text": "Are we a parent or a child?",
@@ -345,7 +354,6 @@ _DEFAULTS = odict({
         'depends': 'AUDIOSERVER',
         "scope": Scopes.AUDIO
     },
-
 })
 """
 Ordered Dictionary containing default values for prefs.


### PR DESCRIPTION
PR for issue 56 https://github.com/wehr-lab/autopilot/issues/56

As I wrote there, this is a non-trivial change, so feedback welcome. Here was my approach:

- I defined a new pref with Scope.TERMINAL called TERMINAL_WINSIZE_BEHAVIOR that takes one of three values: "maximum", "remember", or "moderate".
- For "moderate", the terminal always opens to a 1000x400 pixel size. For "maximum", the terminal always fills the primary display. For "remember", the terminal opens to whatever size it was last time it was closed. The memory is implemented using QSettings restoreGeometry function that jonny linked to. If there is no stored setting, it defaults to "moderate". In the future, QSettings could be an interesting place to store other persistent info about Terminal GUI state if we want. It lives in the ~/.config directory.
- The default behavior is "remember". I recommend this default, because I think the typical user's first experience will be with just one or two Pis, so they don't need maximum screen. And from then on they can resize it, and the Terminal will just remember whatever the last size was. For people like you all with (I'm imagining) large flocks of Pis and therefore want maximum, you would just have to add the pref to be "maximum" in prefs.json, or maximize it once and it would remember from then on.
I can only easily test this on Linux Mint (similar to Ubuntu), not on Darwin. I also haven't tested on multiple monitors. But I tried to maintain compatibility with previous behavior as well as I could, without actually being able to test.

What do you think?