### PR TITLE
v0.3.5 - Fixing pilot db access

### DIFF
--- a/autopilot/__init__.py
+++ b/autopilot/__init__.py
@@ -1,2 +1,2 @@
 __author__  = 'Jonny Saunders <j@nny.fyi>'
-__version__ = '0.3.4'
+__version__ = '0.3.5'

--- a/autopilot/core/gui.py
+++ b/autopilot/core/gui.py
@@ -274,15 +274,8 @@ class Control_Panel(QtWidgets.QWidget):
             if 'state' in val.keys():
                 del val['state']
 
-        try:
-            with open(prefs.get('PILOT_DB'), 'w') as pilot_file:
-                json.dump(self.pilots, pilot_file, indent=4, separators=(',', ': '))
-        except NameError:
-            try:
-                with open('/usr/autopilot/pilot_db.json', 'w') as pilot_file:
-                    json.dump(self.pilots, pilot_file, indent=4, separators=(',', ': '))
-            except IOError:
-                Exception('Couldnt update pilot db!')
+        with open(prefs.get('PILOT_DB'), 'w') as pilot_file:
+            json.dump(self.pilots, pilot_file, indent=4, separators=(',', ': '))
 
 ####################################
 # Control Panel Widgets

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -3,6 +3,7 @@ import json
 import sys
 import os
 from pathlib import Path
+from pprint import pformat
 
 import datetime
 import logging
@@ -406,6 +407,8 @@ class Terminal(QtWidgets.QMainWindow):
                     # Load pilots db as ordered dictionary
                     with open(pilot_db_fn, 'r') as pilot_file:
                         self._pilots = json.load(pilot_file, object_pairs_hook=odict)
+                    self.logger.info(f'successfully loaded pilot_db.json file from {pilot_db_fn}')
+                    self.logger.debug(pformat(self._pilots))
                 except Exception as e:
                     self.logger.exception((f"Exception opening pilot_db.json file at {pilot_db_fn}, got exception: {e}.\n",
                                            "Not proceeding to prevent possibly overwriting corrupt pilot_db.file"))

--- a/autopilot/core/utils.py
+++ b/autopilot/core/utils.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     pass
 
+from collections import OrderedDict as odict
 import json
 import pandas as pd
 from scipy.stats import linregress
@@ -165,23 +166,23 @@ def load_pilotdb(file_name=None, reverse=False):
     Try to load the file_db
 
     Args:
-        reverse:
-        file_name:
+        reverse (bool): Return inverted pilot db mapping subjects: pilots (default False)
+        file_name (str): Path of ``pilot_db.json``, if None, use ``prefs.get('PILOT_DB')``
 
     Returns:
-
+        :class:`collections.OrderedDict` : pilot_db.json or reversed pilot_db
     """
 
     if file_name is None:
-        file_name = '/usr/autopilot/pilot_db.json'
+        file_name = prefs.get('PILOT_DB')
 
     with open(file_name) as pilot_file:
-        pilot_db = json.load(pilot_file)
+        pilot_db = json.load(pilot_file, object_pairs_hook=odict)
 
     if reverse:
         # simplify pilot db
-        pilot_db = {k: v['subjects'] for k, v in pilot_db.items()}
-        pilot_dict = {}
+        pilot_db = odict({k: v['subjects'] for k, v in pilot_db.items()})
+        pilot_dict = odict()
         for pilot, subjectlist in pilot_db.items():
             for ms in subjectlist:
                 pilot_dict[ms] = pilot

--- a/docs/changelog/v0.3.0.rst
+++ b/docs/changelog/v0.3.0.rst
@@ -1,5 +1,18 @@
 .. _changelog_v030:
 
+v0.3.5 (February 22, 2021)
+--------------------------
+
+Bugfixes
+~~~~~~~~
+
+* Very minor one, fixes to the way :class:`.Terminal` accesses the ``pilot_db.json`` file to use :attr:`.Terminal.pilots`
+  property that makes a new pilot_db.json file if one doesn't exist, but otherwise loads the one that is found in
+  ``prefs.get('PILOT_DB')``
+* Reorganized :class:`.Terminal` source to group properties together & minor additions of type hinting
+* Fixed some bad fallback behavior looking for files in old hardcoded default directories, eg. in the ye olde
+  :func:`.utils.get_pilotdb`
+
 v0.3.4 (December 13, 2020)
 ---------------------------
 

--- a/docs/notes/building.txt
+++ b/docs/notes/building.txt
@@ -1,7 +1,7 @@
 deployment
 - write docs
 - write changelog
-- bump version in setup.py
+- bump version in __init__.py
 
 - do PR
 - merge


### PR DESCRIPTION
A very minor bugfix in response to https://github.com/wehr-lab/autopilot/discussions/72#discussioncomment-386330

* Very minor one, fixes to the way :class:`.Terminal` accesses the ``pilot_db.json`` file to use :attr:`.Terminal.pilots`
  property that makes a new pilot_db.json file if one doesn't exist, but otherwise loads the one that is found in
  ``prefs.get('PILOT_DB')``
* Reorganized :class:`.Terminal` source to group properties together & minor additions of type hinting
* Fixed some bad fallback behavior looking for files in old hardcoded default directories, eg. in the ye olde
  :func:`.utils.get_pilotdb`
* bump version to 0.3.5