### PR TITLE
Hotfix - Continuous sounds, pinging pilots, graduation

### DIFF
--- a/autopilot/core/gui.py
+++ b/autopilot/core/gui.py
@@ -17,6 +17,7 @@ the method must be decorated with `@gui_event` which will call perform the updat
 """
 
 import sys
+import typing
 import os
 import json
 import copy
@@ -25,13 +26,11 @@ import time
 from collections import OrderedDict as odict
 import numpy as np
 import ast
-import base64
 from PySide2 import QtGui, QtCore, QtWidgets
 import pyqtgraph as pg
 import pandas as pd
 import itertools
 import threading
-import logging
 from operator import ior
 from functools import reduce
 
@@ -151,14 +150,13 @@ class Control_Panel(QtWidgets.QWidget):
 
         # Make dict to store handles to subjects lists
         self.subject_lists = {}
+        self.panels = {}
 
         # Set layout for whole widget
         self.layout = QtWidgets.QGridLayout()
         self.layout.setContentsMargins(0,0,0,0)
         self.layout.setSpacing(0)
         self.setLayout(self.layout)
-
-        self.panels = {}
 
         self.init_ui()
 
@@ -178,24 +176,35 @@ class Control_Panel(QtWidgets.QWidget):
         self.layout.setColumnStretch(0, 2)
         self.layout.setColumnStretch(1, 2)
 
-        # Iterate through pilots and subjects, making start/stop buttons for pilots and lists of subjects
-        for i, (pilot, subjects) in enumerate(self.pilots.items()):
-            # in pilot dict, format is {'pilot':{'subjects':['subject1',...],'ip':'',etc.}}
-            subjects = subjects['subjects']
-            # Make a list of subjects
-            subject_list = Subject_List(subjects, drop_fn = self.update_db)
-            subject_list.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-            #subject_list.itemDoubleClicked.connect(self.edit_params)
-            self.subject_lists[pilot] = subject_list
+        for pilot_id, pilot_params in self.pilots.items():
+            self.add_pilot(pilot_id, pilot_params.get('subjects', []))
 
-            # Make a panel for pilot control
-            pilot_panel = Pilot_Panel(pilot, subject_list, self.start_fn, self.create_subject)
-            pilot_panel.setFixedWidth(150)
+    def add_pilot(self, pilot_id:str, subjects:typing.Optional[list]=None):
+        """
+        Add a :class:`.Pilot_Panel` for a new pilot, and populate a :class:`.Subject_List` for it
+        Args:
+         pilot_id (str): ID of new pilot
+         subjects (list): Optional, list of any subjects that the pilot has.
+        Returns:
+        """
+        if subjects is None:
+            subjects = []
 
-            self.panels[pilot] = pilot_panel
+        # Make a list of subjects
+        subject_list = Subject_List(subjects, drop_fn=self.update_db)
+        subject_list.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        # subject_list.itemDoubleClicked.connect(self.edit_params)
+        self.subject_lists[pilot_id] = subject_list
 
-            self.layout.addWidget(pilot_panel, i, 1, 1, 1)
-            self.layout.addWidget(subject_list, i, 2, 1, 1)
+        # Make a panel for pilot control
+        pilot_panel = Pilot_Panel(pilot_id, subject_list, self.start_fn, self.create_subject)
+        pilot_panel.setFixedWidth(150)
+        self.panels[pilot_id] = pilot_panel
+
+        row_idx = self.layout.rowCount()
+
+        self.layout.addWidget(pilot_panel, row_idx, 1, 1, 1)
+        self.layout.addWidget(subject_list, row_idx, 2, 1, 1)
 
     def create_subject(self, pilot):
         """
@@ -285,6 +294,11 @@ class Control_Panel(QtWidgets.QWidget):
                 where `'pilot_values'` can be nothing, a list of subjects,
                 or any other information included in the pilot db
         """
+        # if we were given a new pilot, add it
+        if 'new' in kwargs.keys():
+            for pilot, value in kwargs['new'].items():
+                self.pilots[pilot] = value
+
         # gather subjects from lists
         for pilot, mlist in self.subject_lists.items():
             subjects = []
@@ -292,11 +306,6 @@ class Control_Panel(QtWidgets.QWidget):
                 subjects.append(mlist.item(i).text())
 
             self.pilots[pilot]['subjects'] = subjects
-
-        # if we were given a new pilot, add it
-        if 'new' in kwargs.keys():
-            for pilot, value in kwargs['new'].items():
-                self.pilots[pilot] = value
 
         # strip any state that's been stored
         for p, val in self.pilots.items():
@@ -311,7 +320,7 @@ class Control_Panel(QtWidgets.QWidget):
                 with open('/usr/autopilot/pilot_db.json', 'w') as pilot_file:
                     json.dump(self.pilots, pilot_file, indent=4, separators=(',', ': '))
             except IOError:
-                Exception('Couldnt update pilot db!')
+                self.logger.exception('Couldnt update pilot db!')
 
 ####################################
 # Control Panel Widgets

--- a/autopilot/core/networking.py
+++ b/autopilot/core/networking.py
@@ -1041,6 +1041,33 @@ class Pilot_Station(Station):
             'BANDWIDTH': self.l_forward
         })
 
+        # ping back our status to the terminal every so often
+        if prefs.get('PING_INTERVAL') is None:
+            self.ping_interval = 5
+        else:
+            self.ping_interval = float(prefs.get('PING_INTERVAL'))
+
+        self._ping_thread = threading.Timer(self.ping_interval, self._pinger)
+        self._ping_thread.setDaemon(True)
+        self._ping_thread.start()
+
+    def _pinger(self):
+        """
+        Periodically ping the terminal with our status
+
+        Calls its own timer to replace it
+
+
+        Returns:
+
+        """
+        self.l_ping()
+        if not self.closing.is_set():
+            self._ping_thread = threading.Timer(self.ping_interval, self._pinger)
+            self._ping_thread.setDaemon(True)
+            self._ping_thread.start()
+
+
     ###########################3
     # Message/Listen handling methods
 
@@ -1076,7 +1103,7 @@ class Pilot_Station(Station):
 
         pass
 
-    def l_ping(self, msg):
+    def l_ping(self, msg=None):
         """
         The Terminal wants to know our status
 

--- a/autopilot/core/networking.py
+++ b/autopilot/core/networking.py
@@ -31,11 +31,8 @@ from zmq.eventloop.zmqstream import ZMQStream
 from itertools import count
 import numpy as np
 import pdb
-#from pudb.remote import set_trace
-if sys.version_info >= (3,0):
-    import queue
-else:
-    import Queue as queue
+
+import queue
 
 from autopilot import prefs
 from autopilot.core.loggers import init_logger

--- a/autopilot/core/networking.py
+++ b/autopilot/core/networking.py
@@ -916,19 +916,21 @@ class Terminal_Station(Station):
         Args:
             msg (:class:`.Message`):
         """
-        if msg.sender in self.pilots.keys():
+        if msg.sender not in self.pilots.keys():
+            self.pilots[msg.sender] = {}
             #if 'state' in self.pilots[msg.sender].keys():
                 # if msg.value == self.pilots[msg.sender]['state']:
                 #     # if we've already gotten this one, don't send to terminal
                 #     return
-            self.pilots[msg.sender]['state'] = msg.value
 
-            # Tell the terminal so it can update the pilot_db file
-            state = {'state':msg.value, 'pilot':msg.sender}
-            self.send('_T', 'STATE', state)
+        self.pilots[msg.sender]['state'] = msg.value
 
-            # Tell the plot
-            self.send("P_{}".format(msg.sender), 'STATE', msg.value)
+        # Tell the terminal so it can update the pilot_db file
+        state = {'state':msg.value, 'pilot':msg.sender}
+        self.send('_T', 'STATE', state)
+
+        # Tell the plot
+        self.send("P_{}".format(msg.sender), 'STATE', msg.value)
 
         self.senders[msg.sender] = msg.value
 
@@ -1017,7 +1019,7 @@ class Pilot_Station(Station):
         self.id = prefs.get('NAME')
         self.pi_id = "_{}".format(self.id)
         self.subject = None # Store current subject ID
-        self.state = None # store current pi state
+        self.state = 'IDLE' # store current pi state
         self.child = False # Are we acting as a child right now?
         self.parent = False # Are we acting as a parent right now?
 

--- a/autopilot/core/pilot.py
+++ b/autopilot/core/pilot.py
@@ -266,7 +266,7 @@ class Pilot:
         our Station object will cache this and will handle any
         future requests.
         """
-        self.node.send(self.parentid, 'STATE', self.state, flags={'NOLOG':True})
+        self.node.send(self.name, 'STATE', self.state, flags={'NOLOG':True})
 
     def l_start(self, value):
         """

--- a/autopilot/core/subject.py
+++ b/autopilot/core/subject.py
@@ -25,10 +25,8 @@ from autopilot import prefs
 from autopilot.stim.sound.sounds import STRING_PARAMS
 from autopilot.core.loggers import init_logger
 
-if sys.version_info >= (3,0):
-    import queue
-else:
-    import Queue as queue
+import queue
+
 
 # suppress pytables natural name warnings
 warnings.simplefilter('ignore', category=tables.NaturalNameWarning)
@@ -197,7 +195,7 @@ class Subject(object):
         history_row.append()
 
         # we have to always open and close the h5f
-        _ = self.close_hdf(h5f)
+        self.close_hdf(h5f)
 
     def open_hdf(self, mode='r+'):
         """
@@ -237,7 +235,7 @@ class Subject(object):
         """
         with self.lock:
             h5f.flush()
-            return h5f.close()
+            h5f.close()
 
     def new_subject_file(self, biography):
         """
@@ -302,23 +300,12 @@ class Subject(object):
             try:
                 node = h5f.get_node(node[0])
             except tables.exceptions.NoSuchNodeError:
-                #pdb.set_trace()
                 # try to make it
-                # python 3 compatibility
-                if sys.version_info >= (3,0):
-                    if isinstance(node[3], str):
-                        if node[3] == 'group':
-                            h5f.create_group(node[1], node[2])
-                    elif issubclass(node[3], tables.IsDescription):
-                        h5f.create_table(node[1], node[2], description=node[3])
-
-                # python 2
-                else:
-                    if isinstance(node[3], str):
-                        if node[3] == 'group':
-                            h5f.create_group(node[1], node[2])
-                    elif issubclass(node[3], tables.IsDescription):
-                        h5f.create_table(node[1], node[2], description=node[3])
+                if isinstance(node[3], str):
+                    if node[3] == 'group':
+                        h5f.create_group(node[1], node[2])
+                elif issubclass(node[3], tables.IsDescription):
+                    h5f.create_table(node[1], node[2], description=node[3])
 
         self.close_hdf(h5f)
 
@@ -663,19 +650,59 @@ class Subject(object):
         # tasks without TrialData will have some default table, so this should always be present
         trial_table = h5f.get_node(group_name, 'trial_data')
 
+        ##################################3
+        # first try and find some timestamp column to filter past data we give to the graduation object
+        # in case the subject has been stepped back down to a previous stage, for example
+        # FIXME: Hardcoding parameter names, should have a guaranteed 'trial_timestamp' column for each trial
+        slice_start = 0
+        try:
+            ts_cols = [col for col in trial_table.colnames if 'timestamp' in col]
+            # just use the first timestamp column
+            if len(ts_cols) > 0:
+                trial_ts = pd.DataFrame({'timestamp': trial_table.col(ts_cols[0])})
+                trial_ts['timestamp'] = pd.to_datetime(trial_ts['timestamp'].str.decode('utf-8'))
+            else:
+                self.logger.warning(
+                    'No timestamp column could be found in trial data, cannot trim data given to graduation objects')
+                trial_ts = None
+
+            if trial_ts is not None and step_df is not None:
+                # see where, if any, the timestamp column is older than the last time the step was changed
+                good_rows = np.where(trial_ts['timestamp'] >= step_df['timestamp'].iloc[-1])[0]
+                if len(good_rows) > 0:
+                    slice_start = np.min(good_rows)
+                # otherwise if it's because we found no good rows but have trials,
+                # we will say not to use them, otherwise we say not to use them by
+                # slicing at the end of the table
+                else:
+                    slice_start = trial_table.nrows
+
+        except Exception as e:
+            self.logger.exception(
+                f"Couldnt trim data given to graduation objects with step change history, got exception {e}")
+
+        trial_tab = trial_table.read(start=slice_start)
+        trial_tab_keys = tuple(trial_tab.dtype.fields.keys())
+
+        ##############################
+
         # get last trial number and session
         try:
-            self.current_trial = trial_table.cols.trial_num[-1]+1
+            self.current_trial = trial_tab['trial_num'][-1]+1
         except IndexError:
-            self.logger.info('No previous trials detected, setting current_trial to 0')
+            if 'trial_num' not in trial_tab_keys:
+                self.logger.info('No previous trials detected, setting current_trial to 0')
             self.current_trial = 0
 
         # should have gotten session from current node when we started
+        # so sessions increment over the lifespan of the subject, even if
+        # reassigned.
         if not self.session:
             try:
-                self.session = trial_table.cols.session[-1]
+                self.session = trial_tab['session'][-1]
             except IndexError:
-                self.logger.warning('previous session couldnt be found, setting to 0')
+                if 'session' not in trial_tab_keys:
+                    self.logger.warning('previous session couldnt be found, setting to 0')
                 self.session = 0
 
         self.session += 1
@@ -711,38 +738,19 @@ class Subject(object):
                     for param in grad_obj.PARAMS:
                         #if param not in grad_params.keys():
                         # for now, try to find it in our attributes
+                        # but don't overwrite if it already has what it needs in case
+                        # of name overlap
                         # TODO: See where else we would want to get these from
-                        if hasattr(self, param):
+                        if hasattr(self, param) and param not in grad_params.keys():
                             grad_params.update({param:getattr(self, param)})
 
                 if grad_obj.COLS:
                     # these are columns in our trial table
 
-                    # first try and find some timestamp column to filter past data we give to the graduation object
-                    # in case the subject has been stepped back down to a previous stage, for example
-                    # FIXME: Hardcoding parameter names, should have a guaranteed 'trial_timestamp' column for each trial
-                    slice_start = 0
-                    try:
-                        ts_cols = [col for col in trial_table.colnames if 'timestamp' in col]
-                        # just use the first timestamp column
-                        if len(ts_cols) > 0:
-                            trial_ts = pd.DataFrame({'timestamp': trial_table.col(ts_cols[0])})
-                            trial_ts['timestamp'] = pd.to_datetime(trial_ts['timestamp'].str.decode('utf-8'))
-                        else:
-                            self.logger.warning('No timestamp column could be found in trial data, cannot trim data given to graduation objects')
-                            trial_ts = None
-
-                        if trial_ts is not None and step_df is not None:
-                            # see where, if any, the timestamp column is older than the last time the step was changed
-                            slice_start = np.min(np.where(trial_ts['timestamp'] >= step_df['timestamp'].iloc[-1]))
-
-                    except Exception as e:
-                        self.logger.exception(f"Couldnt trim data given to graduation objects with step change history, got exception {e}")
-
                     # then give the data to the graduation object
                     for col in grad_obj.COLS:
                         try:
-                            grad_params.update({col: trial_table.col(col)[slice_start:]})
+                            grad_params.update({col: trial_tab[col]})
                         except KeyError:
                             self.logger.warning('Graduation object requested column {}, but it was not found in the trial table'.format(col))
 

--- a/autopilot/core/subject.py
+++ b/autopilot/core/subject.py
@@ -6,7 +6,6 @@ Currently named subject, but will likely be refactored to include other data
 models should the need arise.
 
 """
-
 # TODO: store pilot in biography
 import os
 import sys
@@ -922,13 +921,13 @@ class Subject(object):
                 # TODO: Or if all the values have been filled, shouldn't need explicit TRIAL_END flags
                 if 'TRIAL_END' in data.keys():
                     trial_row['session'] = self.session
-                    trial_row.append()
-                    trial_table.flush()
                     if self.graduation:
                         # set our graduation flag, the terminal will get the rest rolling
                         did_graduate = self.graduation.update(trial_row)
                         if did_graduate is True:
                             self.did_graduate.set()
+                    trial_row.append()
+                    trial_table.flush()
 
                 # always flush so that our row iteration routines above will find what they're looking for
                 trial_table.flush()

--- a/autopilot/core/terminal.py
+++ b/autopilot/core/terminal.py
@@ -272,7 +272,8 @@ class Terminal(QtWidgets.QMainWindow):
         # Control panel sits on the left, controls pilots & subjects
         self.control_panel = Control_Panel(pilots=self.pilots,
                                            subjects=self.subjects,
-                                           start_fn=self.toggle_start)
+                                           start_fn=self.toggle_start,
+                                           ping_fn=self.ping_pilot)
 
         # Data panel sits on the right, plots stuff.
         self.data_panel = Plot_Widget()
@@ -353,6 +354,9 @@ class Terminal(QtWidgets.QMainWindow):
 
     ##########################3
     # Listens & inter-object methods
+
+    def ping_pilot(self, pilot):
+        self.send(pilot, 'PING')
 
     def heartbeat(self, once=False):
         """

--- a/autopilot/hardware/cameras.py
+++ b/autopilot/hardware/cameras.py
@@ -4,32 +4,17 @@ import sys
 import os
 import csv
 from skvideo import io
-from skvideo.utils import vshape
-import numpy as np
-import base64
 from datetime import datetime
 import multiprocessing as mp
 from tqdm.auto import tqdm
-
 
 import time
 import traceback
 import blosc
 import warnings
 import subprocess
-import logging
-from ctypes import c_char_p
 
-
-
-
-# import the Queue class from Python 3
-if sys.version_info >= (3, 0):
-    from queue import Queue, Empty, Full
-
-# otherwise, import the Queue class for Python 2.7
-else:
-    from Queue import Queue, Empty, Full
+from queue import Queue, Empty, Full
 
 try:
     import PySpin

--- a/autopilot/hardware/i2c.py
+++ b/autopilot/hardware/i2c.py
@@ -13,10 +13,7 @@ import numpy as np
 from itertools import product
 from scipy.interpolate import griddata
 
-if sys.version_info >= (3,0):
-    from queue import Queue, Empty
-else:
-    from Queue import Queue, Empty
+from queue import Queue, Empty
 
 if prefs.get('AGENT') in ['pilot']:
     import pigpio

--- a/autopilot/hardware/usb.py
+++ b/autopilot/hardware/usb.py
@@ -4,10 +4,8 @@ Hardware that uses USB
 import sys
 import threading
 import time
-if sys.version_info >= (3, 0):
-    from queue import Queue, Empty
-else:
-    from Queue import Queue, Empty
+
+from queue import Queue, Empty
 
 import numpy as np
 from inputs import devices

--- a/autopilot/prefs.py
+++ b/autopilot/prefs.py
@@ -270,6 +270,12 @@ _DEFAULTS = odict({
         'text': 'Pins to pull down on system startup? (list of form [1, 2])',
         "scope": Scopes.PILOT
     },
+    'PING_INTERVAL': {
+        'type': 'float',
+        'text': 'How many seconds should pilots wait in between pinging the Terminal?',
+        'default': 5,
+        'scope': Scopes.PILOT
+    },
     'DRAWFPS': {
         'type': 'int',
         "text": "FPS to draw videos displayed during acquisition",

--- a/autopilot/stim/sound/jackclient.py
+++ b/autopilot/stim/sound/jackclient.py
@@ -123,7 +123,7 @@ class JackClient(mp.Process):
         # a few objects that control continuous/background sound.
         # see descriptions in module variables
         self.continuous = mp.Event()
-        self.continuous_q = mp.Queue(maxsize=1024)
+        self.continuous_q = mp.Queue()
         self.continuous_loop = mp.Event()
         self.continuous_cycle = None
         self.continuous.clear()

--- a/autopilot/stim/sound/jackclient.py
+++ b/autopilot/stim/sound/jackclient.py
@@ -1,10 +1,7 @@
 """
 Client that dumps samples directly to the jack client with the :mod:`jack` package.
 """
-
-
-
-
+from itertools import cycle
 import multiprocessing as mp
 import queue as queue
 import numpy as np
@@ -128,9 +125,9 @@ class JackClient(mp.Process):
         self.continuous = mp.Event()
         self.continuous_q = mp.Queue(maxsize=1024)
         self.continuous_loop = mp.Event()
+        self.continuous_cycle = None
         self.continuous.clear()
         self.continuous_loop.clear()
-        self.continuous_started = False
 
         # store the frames of the continuous sound and cycle through them if set in continous mode
         self.continuous_cycle = None
@@ -236,35 +233,26 @@ class JackClient(mp.Process):
         Args:
             frames: number of frames (samples) to be processed. unused. passed by jack client
         """
+
         if not self.play_evt.is_set():
             # if we are in continuous mode...
             if self.continuous.is_set():
+                if self.continuous_cycle is None:
+                    to_cycle = []
+                    while not self.continuous_q.empty():
+                        try:
+                            to_cycle.append(self.continuous_q.get_nowait())
+                        except Empty:
+                            # normal, queue empty
+                            pass
+                    self.continuous_cycle = cycle(to_cycle)
 
-                try:
-                    data = self.continuous_q.get_nowait()
-
-                except Empty:
-                    self.logger.warning('Continuous queue was empty!')
-                    #self.continuous.clear()
-                    data = self.zero_arr
-
-                self.client.outports[0].get_array()[:] = data.T
-
-                # if not self.continuous_started:
-                #     # if we are just entering continuous mode, get the continuous sound and prepare to play it
-                #     continuous_frames = []
-                #     while not self.continuous_q.empty():
-                #         try:
-                #             continuous_frames.append(self.continuous_q.get_nowait())
-                #         except Empty:
-                #             break
-                #     self.continuous_cycle = cycle(continuous_frames)
-                #     self.continuous_started = True
-                #
-                # # FIXME: Multichannel sound....
-                # self.client.outports[0].get_array()[:] = self.continuous_cycle.next().T
+                self.client.outports[0].get_array()[:] = next(self.continuous_cycle).T
 
             else:
+                # clear continuous sound after it's done
+                if self.continuous_cycle is not None:
+                    self.continuous_cycle = None
                 for channel, port in zip(self.zero_arr.T, self.client.outports):
                     port.get_array()[:] = channel
         else:
@@ -277,17 +265,13 @@ class JackClient(mp.Process):
             if data is None:
                 # fill with continuous noise
                 if self.continuous.is_set():
-                    #self.client.outports[0].get_array()[:] = self.continuous_cycle.next().T
                     try:
-                        data = self.continuous_q.get_nowait()
-                    except Empty:
-                        self.logger.warning('Continuous queue was empty!')
-                        # self.continuous.clear()
+                        data = next(self.continuous_cycle)
+                    except Exception as e:
+                        self.logger.exception(f'Continuous mode was set but got exception with continuous queue:\n{e}')
                         data = self.zero_arr
-                        #self.continuous.clear()
 
                     self.client.outports[0].get_array()[:] = data.T
-
 
                 else:
                     for channel, port in zip(self.zero_arr.T, self.client.outports):
@@ -302,17 +286,17 @@ class JackClient(mp.Process):
                     if self.continuous.is_set():
                         # data = np.concatenate((data, self.continuous_cycle.next()[-n_from_end:]),
                         #                       axis=0)
-                        cont_data = self.continuous_q.get_nowait()
-                        data = np.concatenate((data, cont_data[-n_from_end:]),
-                                              axis=0)
+                        try:
+                            cont_data = next(self.continuous_cycle)
+                            data = np.concatenate((data, cont_data[-n_from_end:]),
+                                                  axis=0)
+                        except Exception as e:
+                            self.logger.exception(f'Continuous mode was set but got exception with continuous queue:\n{e}')
+                            data = np.pad(data, (0, n_from_end), 'constant')
                     else:
                         data = np.pad(data, (0, n_from_end), 'constant')
-                #TODO: Fix the multi-output situation so it doesn't get all grumbly.
-                # use cycle so if sound is single channel it gets copied to all outports
 
                 self.client.outports[0].get_array()[:] = data.T
-                #for channel, port in zip(cycle(data.T), self.client.outports):
-                #    port.get_array()[:] = channel
 
 
 

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -37,14 +37,8 @@ from scipy.io import wavfile
 from scipy.signal import resample
 import numpy as np
 import threading
-import logging
 from itertools import cycle
-import warnings
-if sys.version_info >= (3,0):
-    from queue import Empty, Full
-else:
-    from Queue import Empty, Full
-
+from queue import Empty, Full
 
 from autopilot import prefs
 from autopilot.core.loggers import init_logger
@@ -58,8 +52,6 @@ try:
 except:
 #    # TODO: The 'attribute don't exist' type - i think NameError?
     server_type = None
-
-
 
 if server_type in ("pyo", "docs"):
     try:

--- a/autopilot/stim/sound/sounds.py
+++ b/autopilot/stim/sound/sounds.py
@@ -182,7 +182,6 @@ if server_type in ("jack", "docs", True):
             self.continuous_flag = jackclient.CONTINUOUS
             self.continuous_q = jackclient.CONTINUOUS_QUEUE
             self.continuous_loop = jackclient.CONTINUOUS_LOOP
-            self.quitting = threading.Event()
 
             self.initialized = False
             self.buffered = False
@@ -277,10 +276,6 @@ if server_type in ("jack", "docs", True):
             # refresh nsamples
             self.get_nsamples()
 
-
-
-
-
         def buffer(self):
             """
             Dump chunks into the sound queue.
@@ -329,11 +324,6 @@ if server_type in ("jack", "docs", True):
             This method will call :meth:`.quantize_duration` to force duration such that the sound has full frames.
 
             An exception will be raised if the sound has been padded.
-
-
-
-            Returns:
-
             """
 
             # FIXME: Initialized should be more flexible,
@@ -343,13 +333,9 @@ if server_type in ("jack", "docs", True):
             self.initialized = False
 
             if not self.initialized and not self.table:
-                # try:
                 self.quantize_duration()
                 self.init_sound()
                 self.initialized = True
-                # except:
-                #     pass
-                    #TODO: Log this, better error handling here
 
             if not self.chunks:
                 self.chunk()
@@ -369,10 +355,8 @@ if server_type in ("jack", "docs", True):
             # load frames into continuous queue
             for frame in self.chunks:
                 self.continuous_q.put_nowait(frame)
-            # The jack server looks for a None object to clear the play flag
-            # self.continuous_q.put_nowait(None)
-            self.buffered_continuous = True
 
+            self.buffered_continuous = True
 
         def play(self):
             """
@@ -421,57 +405,19 @@ if server_type in ("jack", "docs", True):
             if not loop:
                 raise NotImplementedError('Continuous, unlooped streaming has not been implemented yet!')
 
-            # FIXME: Initialized should be more flexible,
-            # for now just deleting whatever init happened because
-            # continuous sounds are in development
-            self.table = None
-            self.initialized = False
-
-            self.quantize_duration()
-            self.init_sound()
-            self.initialized = True
-            self.chunk()
-
-            # if not self.buffered_continuous:
-            #     self.buffer_continuous()
-            self.continuous_cycle = cycle(self.chunks)
-
-            # start the buffering thread
-            self.cont_thread = threading.Thread(target=self._buffer_continuous)
-            self.cont_thread.setDaemon(True)
-            self.cont_thread.start()
+            if not self.buffered_continuous:
+                self.buffer_continuous()
 
             if loop:
                 self.continuous_loop.set()
             else:
                 self.continuous_loop.clear()
 
-
             # tell the sound server that it has a continuous sound now
             self.continuous_flag.set()
             self.continuous = True
 
-        def _buffer_continuous(self):
 
-            # empty queue
-            while not self.continuous_q.empty():
-                try:
-                    _ = self.continuous_q.get_nowait()
-                except Empty:
-                    # normal, get until it's empty
-                    break
-
-            # want to be able to quit if queue remains full for, say, 20 periods
-            #wait_time = (self.blocksize/float(self.fs))*20
-
-            while not self.quitting.is_set():
-                try:
-                    #self.continuous_q.put(self.continuous_cycle.next(), timeout=wait_time)
-                    self.continuous_q.put_nowait(next(self.continuous_cycle))
-                except Full:
-                    pass
-            # for chunk in self.chunks:
-            #     self.continuous_q.put_nowait(chunk)
 
         def stop_continuous(self):
             """
@@ -483,7 +429,6 @@ if server_type in ("jack", "docs", True):
                 self.logger.warning("stop_continuous called but not a continuous sound!")
                 return
 
-            self.quitting.set()
             self.continuous_flag.clear()
             self.continuous_loop.clear()
 

--- a/autopilot/stim/visual/visuals.py
+++ b/autopilot/stim/visual/visuals.py
@@ -10,10 +10,7 @@ import threading
 import os
 import sys
 import datetime
-if sys.version_info >= (3,0):
-    from queue import Queue, Empty
-else:
-    from queue import Queue, Empty
+from queue import Queue, Empty
 
 #print(prefs._PREFS.items())
 if prefs.get( 'CONFIG'):

--- a/autopilot/tasks/graduation.py
+++ b/autopilot/tasks/graduation.py
@@ -3,6 +3,7 @@ Object that implement Graduation criteria to move between
 different tasks in a protocol.
 """
 
+from autopilot.core.loggers import init_logger
 from collections import deque
 import numpy as np
 from itertools import count
@@ -15,6 +16,9 @@ class Graduation(object):
     `update` method.
 
     """
+    def __init__(self):
+        self.logger = init_logger(self)
+
     PARAMS = []
     """
     list: list of parameters to be defined
@@ -48,6 +52,7 @@ class Accuracy(Graduation):
             window (int):  number of trials to consider in the past.
             **kwargs: should have 'correct' corresponding to the corrects/incorrects of the past.
         """
+        super(Accuracy, self).__init__()
         #super(Accuracy, self).__init__()
         self.threshold = float(threshold)
         self.window    = int(window)
@@ -76,7 +81,7 @@ class Accuracy(Graduation):
         try:
             self.corrects.append(int(row['correct']))
         except KeyError:
-            Warning("key 'correct' not found in trial_row")
+            self.logger.warning("key 'correct' not found in trial_row")
             return False
 
         if len(self.corrects)<self.window:
@@ -104,7 +109,7 @@ class NTrials(Graduation):
             current_trial (int): If not starting from zero, start from here
             **kwargs:
         """
-        #super(NTrials, self).__init__()
+        super(NTrials, self).__init__()
 
         self.n_trials = int(n_trials)
         self.counter = count(start=int(current_trial))
@@ -127,9 +132,8 @@ class NTrials(Graduation):
             # so we just remake it
             try:
                 self.counter = count(int(trials))
-            except:
-                # TODO: Logging here
-                pass
+            except Exception as e:
+                self.logger.exception(f"Got exception updating internal counter from trial_num: {e}")
         else:
             trials = next(self.counter)
 


### PR DESCRIPTION
Fixing unreliable continuous sound playback, graduation problems, and a few QoL fixes

- Filter trial data in `prepare_run` so that subject that are reassigned to old stages that they already have data for don't erroneously use the old data to eg. compute graduation (aka subjects would always autograduate if they have previously passed a protocol level)
- Pilots are better at reporting their state, will ping it periodically to the Terminal, and the Terminal can be asked to ping pilots that it doesn't know the status of.
- Continuous sounds are now something that the jackd server holds locally instead of being continually fed from another thread, which was unreliable and crashed
- Fixes https://github.com/wehr-lab/autopilot/issues/90 - where only the first logger created in a given module would actually log. now the parent module-level logger is created first to hold the fileHandler, which the children then can all use.
- GUI would crash on adding a new pilot from the broken `reset_ui` method in the Terminal. Removed that and made the control panel better at handling new pilots
- cleaning up residue from python 2