### PR TITLE
Connect to multiple CHILDID

### DIFF
--- a/autopilot/networking/station.py
+++ b/autopilot/networking/station.py
@@ -1270,19 +1270,40 @@ class Pilot_Station(Station):
 
     def l_child(self, msg:Message):
         """
-        Telling our child to run a task.
+        Tell one or more children to start running a task.
+
+        By default, the `key` argument passed to `self.send` is 'START'.
+        However, this can be overriden by providing the desired string
+        as `msg.value['KEY']`.
+
+        This checks the pref `CHILDID` to get the names of one or more children.
+        If that pref is a string, sends the message to just that child.
+        If that pref is a list, sends the message to each child in the list.
 
         Args:
-            msg ():
+            msg (): A message to send to the child or children.
 
-        Returns:
-
+        Returns: 
+            nothing
         """
+        # Take `KEY` from msg.value['KEY'] if available
+        # Otherwise, use 'START'
         if 'KEY' in msg.value.keys():
             KEY = msg.value['KEY']
         else:
             KEY = 'START'
-        self.send(to=prefs.get('CHILDID'), key=KEY, value=msg.value)
+        
+        # Get the list of children
+        childid_pref = prefs.get('CHILDID')
+        
+        # Send to one or more children
+        if isinstance(childid_pref, list):
+            # It's a list of multiple children, send to each
+            for childid in pref_childid:
+                self.send(to=childid, key=KEY, value=msg.value)
+        else:
+            # Send to the only child
+            self.send(to=pref_childid, key=KEY, value=msg.value)
 
     def l_forward(self, msg:Message):
         """

--- a/autopilot/networking/station.py
+++ b/autopilot/networking/station.py
@@ -1294,10 +1294,10 @@ class Pilot_Station(Station):
             KEY = 'START'
         
         # Get the list of children
-        childid_pref = prefs.get('CHILDID')
+        pref_childid = prefs.get('CHILDID')
         
         # Send to one or more children
-        if isinstance(childid_pref, list):
+        if isinstance(pref_childid, list):
             # It's a list of multiple children, send to each
             for childid in pref_childid:
                 self.send(to=childid, key=KEY, value=msg.value)

--- a/autopilot/prefs.py
+++ b/autopilot/prefs.py
@@ -315,8 +315,9 @@ _DEFAULTS = odict({
         "scope": Scopes.LINEAGE
     },
     'CHILDID': {
-        'type': 'str',
-        "text": "Child ID:",
+        'type': 'list',
+        "text": "List of Child ID:",
+        'default': [],
         "depends": ("LINEAGE", "PARENT"),
         "scope": Scopes.LINEAGE
     },


### PR DESCRIPTION
This PR addresses issue https://github.com/wehr-lab/autopilot/issues/101

If CHILDID is a string, the behavior is the same as before.
If CHILDID is a list, then the `l_child` function now broadcasts 'START' to each child named in CHILDID.

I also documented the change in prefs and changed the default to an empty list. I wasn't sure how to indicate that a pref could be a str or a list, but `list` is more capable because it can still be a list of length 1.